### PR TITLE
Make it easier to run uttu locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,5 +88,8 @@ fabric.properties
 # Editor-based Rest Client
 .idea/httpRequests
 
-.gitignore
 .idea/
+*.iml
+target
+files
+dataset.zip

--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ Install Postgres, either via [brew](https://gist.github.com/ibraheem4/ce5ccd3e4d
 or [postgresql.org](https://www.postgresql.org/download/).
 
 For brew install, also install PostGIS: `brew install postgis` (should be included in Postgres.app and EnterpriseDB Postgres installations).
-
+Create folder for database `mkdir db`
+Initialise database `initdb ./db`
+Start db service: `pg_ctl -D ./db/ -l logfile start`
+Create db with your username: `createdb `whoami``
 Create uttu database: `createdb uttu`
 
 Create uttu user: `createuser -s uttu` (you might also have to create a `postgres` user)
@@ -84,4 +87,3 @@ With metadata:
                 }
             ]
         }
-

--- a/README.md
+++ b/README.md
@@ -1,12 +1,39 @@
 # Uttu [![CircleCI](https://circleci.com/gh/entur/uttu/tree/master.svg?style=svg)](https://circleci.com/gh/entur/uttu/tree/master)
 
-Back end for FlexibleLine with FlexibleAreas timetable data editor and export module
+Back end for [Flexible Transport Editor](https://github.com/entur/flexible-transport)
 
 ## Graphql 
 https://api.dev.entur.io/timetable-admin/v1/flexible-lines/providers/graphql
 
-When running locally
+## Running locally
+### Build
+You need Java 11, Maven 3 or higher, and a `settings.xml`-file that gives you access to the internal repo (ask a friend).
+
+### Database
+Install Postgres, either via [brew](https://gist.github.com/ibraheem4/ce5ccd3e4d7a65589ce84f2a3b7c23a3), [postgresapp.com](http://postgresapp.com/),
+or [postgresql.org](https://www.postgresql.org/download/).
+
+For brew install, also install PostGIS: `brew install postgis` (should be included in Postgres.app and EnterpriseDB Postgres installations).
+
+Create uttu database: `createdb uttu`
+
+Create uttu user: `createuser -s uttu` (you might also have to create a `postgres` user)
+
+Run the [migrations](src/main/resources/db.migration) in order.
+
+Run the initial [data import](src/main/resources/import.sql)
+
+### Run
+**IntelliJ**: Right-click on `App.java` and choose Run (or Cmd+Shift+F10). Open Run -> Edit configurations, choose the
+correct configuration (Spring Boot -> App), and add `local` to Active profiles. Save the configuration.
+
+**Command line**: `mvn spring-boot:run`
+
+### GraphQL endpoint
 http://localhost:11701/services/flexible-lines/rut/graphql
+
+## Netex Export
+This api exports generated netex file to gcp storage, which is used to build graph.
 
 ### Error code extension
 
@@ -41,5 +68,3 @@ With metadata:
             ]
         }
 
-## Netex Export
-This api exports generated netex file to gcp storage, which is used to build graph.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ https://api.dev.entur.io/timetable-admin/v1/flexible-lines/providers/graphql
 You need Java 11, Maven 3 or higher, and a `settings.xml`-file that gives you access to the internal repo (ask a friend).
 
 ### Database
+
+#### Via local installation of database
 Install Postgres, either via [brew](https://gist.github.com/ibraheem4/ce5ccd3e4d7a65589ce84f2a3b7c23a3), [postgresapp.com](http://postgresapp.com/),
 or [postgresql.org](https://www.postgresql.org/download/).
 
@@ -22,6 +24,21 @@ Create uttu user: `createuser -s uttu` (you might also have to create a `postgre
 Run the [migrations](src/main/resources/db.migration) in order.
 
 Run the initial [data import](src/main/resources/import.sql)
+
+#### Via Docker
+
+Install Docker.
+
+```bash
+docker run --name=uttu -d -e POSTGRES_USER=uttu -e POSTGRES_PASS=uttu -e POSTGRES_DBNAME=uttu -e ALLOW_IP_RANGE=0.0.0.0/0 -p 5432:5432 -v db_local:/var/lib/postgresql --restart=always kartoza/postgis:9.6-2.4
+```
+
+Now a Docker container is running in the background. Check its status with `docker ps`.
+
+To stop, find its ID from `docker ps`, and run `docker stop theid` (beginning of hash). To restart it, find the ID from `docker container list` and run `docker restart theid`.
+
+Run the [script](./src/main/resources/db_init.sh).
+
 
 ### Run
 **IntelliJ**: Right-click on `App.java` and choose Run (or Cmd+Shift+F10). Open Run -> Edit configurations, choose the

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Create uttu database: `createdb uttu`
 
 Create uttu user: `createuser -s uttu` (you might also have to create a `postgres` user)
 
-Run the [migrations](src/main/resources/db.migration) in order.
+Run the [script](./src/main/resources/db_init.sh)
 
 Run the initial [data import](src/main/resources/import.sql)
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Create uttu user: `createuser -s uttu` (you might also have to create a `postgre
 
 Run the [script](./src/main/resources/db_init.sh)
 
-Run the initial [data import](src/main/resources/import.sql)
 
 #### Via Docker
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <packaging>jar</packaging>
 
     <name>uttu</name>
-    <description>Back end for Flexible Line with Flexible Areas timetable data editor and export module</description>
+    <description>Backend for Flexible Transport Editor</description>
 
     <scm>
         <connection>scm:git:ssh://git@github.com/entur/uttu.git</connection>
@@ -37,13 +37,15 @@
     </scm>
 
     <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+
         <!-- versions for use in mvn plugins as we cannot inherit them from a BOM -->
         <entur.helpers.version>0.0.6-SNAPSHOT</entur.helpers.version>
         <keycloak.version>5.0.0</keycloak.version>
 
         <entur-google-pubsub-version>0.0.6-SNAPSHOT</entur-google-pubsub-version>
         <gcp-storage.version>0.0.6-SNAPSHOT</gcp-storage.version>
-
 
         <geodb.version>0.9</geodb.version>
         <geotools.version>20.1</geotools.version>
@@ -59,7 +61,6 @@
         <com.h2database.version>1.4.196</com.h2database.version>
 
         <guava.version>28.1-jre</guava.version>
-
     </properties>
 
     <dependencies>
@@ -151,7 +152,6 @@
                     <groupId>org.hibernate</groupId>
                     <artifactId>hibernate-core</artifactId>
                 </exclusion>
-
             </exclusions>
         </dependency>
 
@@ -334,7 +334,6 @@
             <artifactId>entur-google-pubsub</artifactId>
             <version>${entur-google-pubsub-version}</version>
         </dependency>
-
     </dependencies>
 
     <build>
@@ -363,11 +362,15 @@
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
                     <mainClass>no.entur.uttu.App</mainClass>
+                    <profiles>
+                        <profile>local</profile>
+                    </profiles>
                 </configuration>
                 <executions>
                     <execution>
@@ -404,7 +407,35 @@
                 </executions>
             </plugin>
 
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <generateBackupPoms>false</generateBackupPoms>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>${maven-enforcer-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>enforce</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules combine.children="append">
+                                <requireMavenVersion>
+                                    <version>3</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
-
 </project>

--- a/src/main/java/no/entur/uttu/export/blob/LocalDiskBlobStoreService.java
+++ b/src/main/java/no/entur/uttu/export/blob/LocalDiskBlobStoreService.java
@@ -28,7 +28,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 @Component
-@Profile("local-blobstore")
+@Profile("local")
 public class LocalDiskBlobStoreService implements BlobStoreService {
 
     @Value("${blobstore.local.folder:files/blob}")

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,0 +1,25 @@
+server.port=11701
+server.host=localhost
+spring.profiles.active=local
+
+spring.jpa.database=POSTGRESQL
+spring.datasource.platform=postgres
+spring.jpa.show-sql=false
+spring.jpa.hibernate.ddl-auto=none
+spring.jpa.properties.hibernate.dialect=org.hibernate.spatial.dialect.postgis.PostgisDialect
+spring.jpa.hibernate.use-new-pk-generator-mappings=true
+spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults = false
+spring.jpa.open-in-view=false
+spring.jpa.properties.hibernate.format_sql=true
+spring.database.driverClassName=org.postgresql.Driver
+spring.datasource.url=jdbc:postgresql://127.0.0.1:5432/uttu
+
+keycloak.realm=rutebanken
+keycloak.auth-server-url=https://kc-dev.devstage.entur.io/auth
+keycloak.resource=uttu
+
+authorization.enabled=true
+## TODO remove when keycloak spring sec adapter is fixed
+spring.main.allow-bean-definition-overriding=true
+spring.flyway.enabled=false
+organisation.registry.url=https://api.dev.entur.io/organisations/v1/register/organisations/

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -12,6 +12,8 @@ spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults = false
 spring.jpa.open-in-view=false
 spring.jpa.properties.hibernate.format_sql=true
 spring.database.driverClassName=org.postgresql.Driver
+spring.datasource.username=uttu
+spring.datasource.password=uttu
 spring.datasource.url=jdbc:postgresql://127.0.0.1:5432/uttu
 
 keycloak.realm=rutebanken

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -23,3 +23,5 @@ authorization.enabled=true
 spring.main.allow-bean-definition-overriding=true
 spring.flyway.enabled=false
 organisation.registry.url=https://api.dev.entur.io/organisations/v1/register/organisations/
+
+spring.cloud.gcp.project-id=default

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -24,4 +24,4 @@ spring.main.allow-bean-definition-overriding=true
 spring.flyway.enabled=false
 organisation.registry.url=https://api.dev.entur.io/organisations/v1/register/organisations/
 
-spring.cloud.gcp.project-id=default
+#spring.cloud.gcp.project-id=default

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -24,4 +24,5 @@ spring.main.allow-bean-definition-overriding=true
 spring.flyway.enabled=false
 organisation.registry.url=https://api.dev.entur.io/organisations/v1/register/organisations/
 
-#spring.cloud.gcp.project-id=default
+spring.cloud.gcp.project-id=default
+spring.cloud.gcp.pubsub.emulatorHost=localhost:8088

--- a/src/main/resources/db_init.sh
+++ b/src/main/resources/db_init.sh
@@ -1,0 +1,12 @@
+#!/bin/bash  -e
+
+for f in ./db/migration/V1__Base_version.sql \
+           ./db/migration/V2__Add_Export_filename.sql \
+           ./db/migration/V3__Remove_unique_order_constraints.sql \
+           ./db/migration/V4__Increased_text_column_length.sql \
+           ./db/migration/V5__Increased_booking_note_text_column_length.sql \
+           ./import.sql
+do
+  echo "Running migration for ${f}"
+  PGPASSWORD=uttu psql -U uttu -h localhost -p 5432 -f $f
+done

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -43,6 +43,17 @@
                 </providers>
             </encoder>
         </appender>
+
+        <springProfile name="local">
+            <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+                <layout class="ch.qos.logback.classic.PatternLayout">
+                    <Pattern>
+                        %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{70} - %msg%n
+                    </Pattern>
+                </layout>
+            </appender>
+        </springProfile>
+
         <logger name="com" level="INFO"/>
         <logger name="no" level="INFO"/>
         <logger name="org" level="INFO"/>

--- a/src/test/java/no/entur/uttu/UttuIntegrationTest.java
+++ b/src/test/java/no/entur/uttu/UttuIntegrationTest.java
@@ -24,7 +24,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = UttuTestApp.class)
-@ActiveProfiles({"geodb", "local-blobstore", "google-pubsub-emulator"})
+@ActiveProfiles({"geodb", "local", "google-pubsub-emulator"})
 @EnableAspectJAutoProxy(proxyTargetClass = true)
 public abstract class UttuIntegrationTest {
 

--- a/src/test/resources/application-local.properties
+++ b/src/test/resources/application-local.properties
@@ -3,9 +3,9 @@
 # the European Commission - subsequent versions of the EUPL (the "Licence");
 # You may not use this work except in compliance with the Licence.
 # You may obtain a copy of the Licence at:
-#  
+#
 #   https://joinup.ec.europa.eu/software/page/eupl
-#  
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the Licence is distributed on an "AS IS" basis,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,7 +28,7 @@ spring.jpa.open-in-view=false
 spring.flyway.enabled=false
 
 
-spring.profiles.active=local-blobstore
+spring.profiles.active=local
 
 spring.jpa.properties.hibernate.dialect=org.hibernate.spatial.dialect.h2geodb.GeoDBDialect
 


### PR DESCRIPTION
Added a recipe for running uttu locally to the README.

Basically created a Spring application properties file for running locally, and made the spring-boot-maven-plugin use the `local` profile so that it picks up those application properties (and included how to do the same for running in IntelliJ in the README).