### PR TITLE
WTK-222 Fix line deletion

### DIFF
--- a/src/main/java/no/entur/uttu/model/job/ExportLineAssociation.java
+++ b/src/main/java/no/entur/uttu/model/job/ExportLineAssociation.java
@@ -4,7 +4,6 @@ import no.entur.uttu.model.Line;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;

--- a/src/main/java/no/entur/uttu/model/job/ExportLineAssociation.java
+++ b/src/main/java/no/entur/uttu/model/job/ExportLineAssociation.java
@@ -1,12 +1,14 @@
 package no.entur.uttu.model.job;
 
 import no.entur.uttu.model.Line;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToOne;
 import javax.validation.constraints.NotNull;
 
 @Entity
@@ -19,7 +21,8 @@ public class ExportLineAssociation {
     @NotNull
     private Export export;
 
-    @OneToOne
+    @ManyToOne
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @NotNull
     private Line line;
 

--- a/src/main/resources/db/migration/V8__On_delete_cascade_line_fkey_in_export_line_association.sql
+++ b/src/main/resources/db/migration/V8__On_delete_cascade_line_fkey_in_export_line_association.sql
@@ -1,0 +1,3 @@
+ALTER TABLE ONLY export_line_association
+    DROP CONSTRAINT line_fkey,
+    ADD CONSTRAINT line_fkey FOREIGN KEY (line_pk) REFERENCES line(pk) ON DELETE CASCADE;

--- a/src/test/groovy/no/entur/uttu/graphql/ExportGraphQLIntegrationTest.groovy
+++ b/src/test/groovy/no/entur/uttu/graphql/ExportGraphQLIntegrationTest.groovy
@@ -81,5 +81,23 @@ class ExportGraphQLIntegrationTest extends AbstractFlexibleLinesGraphQLIntegrati
                 .statusCode(200)
                 .body(not(isEmptyOrNullString()))
 
+
+        String deleteLineMutation = """
+ mutation DeleteLine(\$id: ID!) {
+  deleteFlexibleLine(id: \$id) {
+    id
+  }
+  }
+         """
+
+        String deleteLineVariables = """
+{
+  "id": "$lineRef"
+}
+"""
+
+
+        ValidatableResponse deleteLineRsp = executeGraphQL(deleteLineMutation, deleteLineVariables)
+                .body("data.deleteFlexibleLine.id", equalTo(lineRef))
     }
 }


### PR DESCRIPTION
Deleting a line resulted in foreign key constraint violation on export line association. This adds a on delete cascade to the line foreign key, so that when a line is deleted, the export line association is also deleted.