### PR TITLE
Add service journey operator refs to export context

### DIFF
--- a/src/main/java/no/entur/uttu/export/netex/producer/line/ServiceJourneyProducer.java
+++ b/src/main/java/no/entur/uttu/export/netex/producer/line/ServiceJourneyProducer.java
@@ -65,6 +65,7 @@ public class ServiceJourneyProducer {
         OperatorRefStructure operatorRefStructure = null;
         if (local.getOperatorRef() != null) {
             operatorRefStructure = organisationProducer.produceOperatorRef(local.getOperatorRef(), false, context);
+            context.operatorRefs.add(local.getOperatorRef());
         }
 
         List<DayType> validDayTypes = local.getDayTypes().stream().filter(context::isValid).collect(Collectors.toList());


### PR DESCRIPTION
Operator refs in the export context are added to organisations in common file.