### PR TITLE
Validation related fixes

### DIFF
--- a/src/main/java/no/entur/uttu/export/netex/producer/line/ServiceJourneyProducer.java
+++ b/src/main/java/no/entur/uttu/export/netex/producer/line/ServiceJourneyProducer.java
@@ -16,6 +16,7 @@
 package no.entur.uttu.export.netex.producer.line;
 
 import no.entur.uttu.export.netex.NetexExportContext;
+import no.entur.uttu.export.netex.producer.NetexIdProducer;
 import no.entur.uttu.export.netex.producer.NetexObjectFactory;
 import no.entur.uttu.export.netex.producer.common.OrganisationProducer;
 import no.entur.uttu.model.BookingArrangement;
@@ -47,6 +48,8 @@ import java.math.BigInteger;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import static no.entur.uttu.export.netex.producer.NetexObjectFactory.VERSION_ONE;
 
 @Component
 public class ServiceJourneyProducer {
@@ -92,7 +95,7 @@ public class ServiceJourneyProducer {
         return objectFactory.populate(new org.rutebanken.netex.model.ServiceJourney(), local)
                        .withJourneyPatternRef(journeyPatternRef)
                        .withName(objectFactory.createMultilingualString(local.getName()))
-                       .withFlexibleServiceProperties(mapFlexibleServiceProperties(local.getBookingArrangement()))
+                       .withFlexibleServiceProperties(mapFlexibleServiceProperties(local.getBookingArrangement(), context))
                        .withPublicCode(local.getPublicCode())
                        .withOperatorRef(operatorRefStructure)
                        .withPassingTimes(new TimetabledPassingTimes_RelStructure().withTimetabledPassingTime(timetabledPassingTimes))
@@ -130,21 +133,23 @@ public class ServiceJourneyProducer {
     }
 
 
-    private FlexibleServiceProperties mapFlexibleServiceProperties(BookingArrangement local) {
+    private FlexibleServiceProperties mapFlexibleServiceProperties(BookingArrangement local, NetexExportContext context) {
         if (local == null) {
             return null;
         }
 
         // TODO flexibleSerivceType?
         return new FlexibleServiceProperties()
-                       .withBookingAccess(objectFactory.mapEnum(local.getBookingAccess(), BookingAccessEnumeration.class))
-                       .withBookingMethods(objectFactory.mapEnums(local.getBookingMethods(), BookingMethodEnumeration.class))
-                       .withBookWhen(objectFactory.mapEnum(local.getBookWhen(), PurchaseWhenEnumeration.class))
-                       .withBuyWhen(objectFactory.mapEnums(local.getBuyWhen(), PurchaseMomentEnumeration.class))
-                       .withLatestBookingTime(local.getLatestBookingTime())
-                       .withMinimumBookingPeriod(local.getMinimumBookingPeriod())
-                       .withBookingNote(objectFactory.createMultilingualString(local.getBookingNote()))
-                       .withBookingContact(contactStructureProducer.mapContactStructure(local.getBookingContact()));
+                .withId(NetexIdProducer.generateId(FlexibleServiceProperties.class, context))
+                .withVersion(VERSION_ONE)
+                .withBookingAccess(objectFactory.mapEnum(local.getBookingAccess(), BookingAccessEnumeration.class))
+                .withBookingMethods(objectFactory.mapEnums(local.getBookingMethods(), BookingMethodEnumeration.class))
+                .withBookWhen(objectFactory.mapEnum(local.getBookWhen(), PurchaseWhenEnumeration.class))
+                .withBuyWhen(objectFactory.mapEnums(local.getBuyWhen(), PurchaseMomentEnumeration.class))
+                .withLatestBookingTime(local.getLatestBookingTime())
+                .withMinimumBookingPeriod(local.getMinimumBookingPeriod())
+                .withBookingNote(objectFactory.createMultilingualString(local.getBookingNote()))
+                .withBookingContact(contactStructureProducer.mapContactStructure(local.getBookingContact()));
 
     }
 }

--- a/src/main/java/no/entur/uttu/model/BookingArrangement.java
+++ b/src/main/java/no/entur/uttu/model/BookingArrangement.java
@@ -16,6 +16,8 @@
 package no.entur.uttu.model;
 
 
+import no.entur.uttu.util.Preconditions;
+
 import javax.persistence.CascadeType;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
@@ -110,5 +112,31 @@ public class BookingArrangement extends IdentifiedEntity {
 
     public void setBuyWhen(List<PurchaseMomentEnumeration> buyWhen) {
         this.buyWhen = buyWhen;
+    }
+
+    @Override
+    public void checkPersistable() {
+        super.checkPersistable();
+
+        Preconditions.checkArgument(
+                // notExist(BookWhen xor LatestBookingTime)
+                getLatestBookingTime() == null || getBookWhen() != null,
+                "%s booking information must have BookWhen when LatestBookingTime is defined",
+                this
+        );
+
+        Preconditions.checkArgument(
+                // notExist(BookWhen and MinimumBookingPeriod)
+                getMinimumBookingPeriod() == null || getBookWhen() == null,
+                "%s booking information can't have BookWhen when MinimumBookingPeriod is defined",
+                this
+        );
+
+        Preconditions.checkArgument(
+                // notExist( not(BookWhen) and not(MinimumBookingPeriod))
+                getBookWhen() != null || getMinimumBookingPeriod() != null,
+                "%s booking information must have BookWhen or MinimumBookingPeriod",
+                this
+        );
     }
 }

--- a/src/main/java/no/entur/uttu/model/FlexibleLine.java
+++ b/src/main/java/no/entur/uttu/model/FlexibleLine.java
@@ -15,6 +15,8 @@
 
 package no.entur.uttu.model;
 
+import no.entur.uttu.util.Preconditions;
+
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -51,5 +53,22 @@ public class FlexibleLine extends Line {
     @Override
     public void accept(LineVisitor lineVisitor) {
         lineVisitor.visitFlexibleLine(this);
+    }
+
+    @Override
+    public void checkPersistable() {
+        super.checkPersistable();
+
+        Preconditions.checkArgument(bookingInformationPresentInHierarchy(),
+                "%s requires booking information on line, journey pattern or service journey", identity());
+    }
+
+    private boolean bookingInformationPresentInHierarchy() {
+        return this.bookingArrangement != null ||
+                this.getJourneyPatterns().stream().anyMatch(jp ->
+                        jp.getPointsInSequence().stream().anyMatch(point -> point.getBookingArrangement() != null) ||
+                                jp.getServiceJourneys().stream().anyMatch(sj -> sj.getBookingArrangement() != null)
+                );
+
     }
 }

--- a/src/main/java/no/entur/uttu/model/FlexibleLine.java
+++ b/src/main/java/no/entur/uttu/model/FlexibleLine.java
@@ -61,6 +61,8 @@ public class FlexibleLine extends Line {
 
         Preconditions.checkArgument(bookingInformationPresentInHierarchy(),
                 "%s requires booking information on line, journey pattern or service journey", identity());
+
+        validateBookingInformations();
     }
 
     private boolean bookingInformationPresentInHierarchy() {
@@ -70,5 +72,19 @@ public class FlexibleLine extends Line {
                                 jp.getServiceJourneys().stream().anyMatch(sj -> sj.getBookingArrangement() != null)
                 );
 
+    }
+
+    private void validateBookingInformations() {
+        validateBookingInformation(this.bookingArrangement);
+        this.getJourneyPatterns().stream().forEach(jp -> {
+            jp.getPointsInSequence().stream().forEach(stopPoint -> validateBookingInformation(stopPoint.getBookingArrangement()));
+            jp.getServiceJourneys().stream().forEach(sj -> validateBookingInformation(sj.getBookingArrangement()));
+        });
+
+    }
+
+    private void validateBookingInformation(BookingArrangement bookingArrangement) {
+        if (bookingArrangement == null) return;
+        bookingArrangement.checkPersistable();
     }
 }

--- a/src/main/java/no/entur/uttu/model/JourneyPattern.java
+++ b/src/main/java/no/entur/uttu/model/JourneyPattern.java
@@ -134,6 +134,9 @@ public class JourneyPattern extends GroupOfEntities_VersionStructure {
         Preconditions.checkArgument(!Boolean.FALSE.equals(getPointsInSequence().get(getPointsInSequence().size() - 1).getForAlighting()),
                 "%s does not permit alighting on last pointsInSequence", identity());
 
+        Preconditions.checkArgument(getPointsInSequence().get(getPointsInSequence().size() -1).getDestinationDisplay() == null,
+                "%s has destinationDisplay for last pointsInSequence", identity());
+
         getServiceJourneys().stream().forEach(ProviderEntity::checkPersistable);
     }
 }

--- a/src/main/java/no/entur/uttu/model/Notice.java
+++ b/src/main/java/no/entur/uttu/model/Notice.java
@@ -15,6 +15,8 @@
 
 package no.entur.uttu.model;
 
+import no.entur.uttu.util.Preconditions;
+
 import javax.persistence.Entity;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -32,5 +34,16 @@ public class Notice extends ProviderEntity {
 
     public void setText(String text) {
         this.text = text;
+    }
+
+    public Notice withText(String text) {
+        this.text = text;
+        return this;
+    }
+
+    @Override
+    public void checkPersistable() {
+        super.checkPersistable();
+        Preconditions.checkArgument(text != null && !text.isEmpty(), "Notice text cannot be empty");
     }
 }

--- a/src/main/java/no/entur/uttu/model/TimetabledPassingTime.java
+++ b/src/main/java/no/entur/uttu/model/TimetabledPassingTime.java
@@ -201,6 +201,7 @@ public class TimetabledPassingTime extends ProviderEntity {
         Preconditions.checkArgument(ValidationHelper.isNotAfter(arrivalTime, arrivalDayOffset, departureTime, departureDayOffset), "%s arrivalTime cannot be later than departureTime", identity());
         Preconditions.checkArgument(ValidationHelper.isNotAfter(earliestDepartureTime, earliestDepartureDayOffset, departureTime, departureDayOffset), "%s earliestDepartureTime cannot be later than departureTime", identity());
         Preconditions.checkArgument(ValidationHelper.isNotAfter(arrivalTime, arrivalDayOffset, latestArrivalTime, latestArrivalDayOffset), "%s arrivalTime cannot be later than latestArrivalTime", identity());
+        Preconditions.checkArgument(ValidationHelper.isNotSame(arrivalTime, arrivalDayOffset, departureTime, departureDayOffset), "%s arrivalTime and departureTime cannot be the same, use departureTime only", identity());
     }
 
 

--- a/src/main/java/no/entur/uttu/util/ValidationHelper.java
+++ b/src/main/java/no/entur/uttu/util/ValidationHelper.java
@@ -42,4 +42,16 @@ public class ValidationHelper {
         return !thisTime.isAfter(otherTime);
     }
 
+    public static boolean isNotSame(LocalTime thisTime, int thisDayOffset, LocalTime otherTime, int otherDayOffset) {
+        if (thisTime == null || otherTime == null) {
+            return true;
+        }
+
+        if (thisDayOffset != otherDayOffset) {
+            return thisDayOffset < otherDayOffset;
+        }
+
+        return !thisTime.equals(otherTime);
+    }
+
 }

--- a/src/main/java/no/entur/uttu/util/ValidationHelper.java
+++ b/src/main/java/no/entur/uttu/util/ValidationHelper.java
@@ -48,7 +48,7 @@ public class ValidationHelper {
         }
 
         if (thisDayOffset != otherDayOffset) {
-            return thisDayOffset < otherDayOffset;
+            return true;
         }
 
         return !thisTime.equals(otherTime);

--- a/src/test/groovy/no/entur/uttu/graphql/AbstractFlexibleLinesGraphQLIntegrationTest.groovy
+++ b/src/test/groovy/no/entur/uttu/graphql/AbstractFlexibleLinesGraphQLIntegrationTest.groovy
@@ -183,7 +183,6 @@ abstract class AbstractFlexibleLinesGraphQLIntegrationTest extends AbstractGraph
       }
     ],
     "bookingArrangement": {
-      "latestBookingTime": "12:00",
       "minimumBookingPeriod": "PT2H",
       "bookingNote": "Notis for booking av linje",
       "bookingMethods": [
@@ -191,7 +190,6 @@ abstract class AbstractFlexibleLinesGraphQLIntegrationTest extends AbstractGraph
         "callDriver"
       ],
       "bookingAccess": "authorisedPublic",
-      "bookWhen": "untilPreviousDay",
       "buyWhen": [
         "afterBoarding",
         "beforeBoarding"

--- a/src/test/java/no/entur/uttu/model/BookingArrangementTest.java
+++ b/src/test/java/no/entur/uttu/model/BookingArrangementTest.java
@@ -1,0 +1,53 @@
+package no.entur.uttu.model;
+
+import org.junit.Test;
+
+import java.time.Duration;
+import java.time.LocalTime;
+
+import static no.entur.uttu.model.ModelTestUtil.assertCheckPersistableFails;
+
+public class BookingArrangementTest {
+    @Test
+    public void checkPersistable_LatestBookingTimeWithoutBookWhen_givesException() {
+        BookingArrangement bookingArrangement = new BookingArrangement();
+        bookingArrangement.setLatestBookingTime(LocalTime.NOON);
+        assertCheckPersistableFails(bookingArrangement);
+    }
+
+    @Test
+    public void checkPersistable_LatestBookingTimeWithBookWhen_succeeds() {
+        BookingArrangement bookingArrangement = new BookingArrangement();
+        bookingArrangement.setLatestBookingTime(LocalTime.NOON);
+        bookingArrangement.setBookWhen(PurchaseWhenEnumeration.DAY_OF_TRAVEL_ONLY);
+        bookingArrangement.checkPersistable();
+    }
+
+    @Test
+    public void checkPersistable_MinimumBookingPeriodWithBookWhen_givesException() {
+        BookingArrangement bookingArrangement = new BookingArrangement();
+        bookingArrangement.setMinimumBookingPeriod(Duration.ofSeconds(3600));
+        bookingArrangement.setBookWhen(PurchaseWhenEnumeration.DAY_OF_TRAVEL_ONLY);
+        assertCheckPersistableFails(bookingArrangement);
+    }
+
+    @Test
+    public void checkPersistable_MinimumBookingPeriodWithoutBookWhen_succeeds() {
+        BookingArrangement bookingArrangement = new BookingArrangement();
+        bookingArrangement.setMinimumBookingPeriod(Duration.ofSeconds(3600));
+        bookingArrangement.checkPersistable();
+    }
+
+    @Test
+    public void checkPersistable_WithoutBookWhenOrMinimumBookingPeriod_givesException() {
+        BookingArrangement bookingArrangement = new BookingArrangement();
+        assertCheckPersistableFails(bookingArrangement);
+    }
+
+    @Test
+    public void checkPersistable_WithBookWhenOnly_succeeds() {
+        BookingArrangement bookingArrangement = new BookingArrangement();
+        bookingArrangement.setBookWhen(PurchaseWhenEnumeration.DAY_OF_TRAVEL_ONLY);
+        bookingArrangement.checkPersistable();
+    }
+}

--- a/src/test/java/no/entur/uttu/model/FixedLineTest.java
+++ b/src/test/java/no/entur/uttu/model/FixedLineTest.java
@@ -34,7 +34,9 @@ public class FixedLineTest {
         FlexibleStopPlace flexibleStopPlace = new FlexibleStopPlace();
         stopPointInJourneyPattern.setFlexibleStopPlace(flexibleStopPlace);
         stopPointInJourneyPattern.setDestinationDisplay(new DestinationDisplay());
-        journeyPattern.setPointsInSequence(Arrays.asList(stopPointInJourneyPattern, stopPointInJourneyPattern));
+        StopPointInJourneyPattern secondStopPointInJourneyPattern = new StopPointInJourneyPattern();
+        secondStopPointInJourneyPattern.setFlexibleStopPlace(flexibleStopPlace);
+        journeyPattern.setPointsInSequence(Arrays.asList(stopPointInJourneyPattern, secondStopPointInJourneyPattern));
         fixedLine.setJourneyPatterns(Collections.singletonList(journeyPattern));
         assertCheckPersistableFailsWithErrorCode(fixedLine, ErrorCodeEnumeration.FLEXIBLE_STOP_PLACE_NOT_ALLOWED);
     }

--- a/src/test/java/no/entur/uttu/model/FlexibleLineTest.java
+++ b/src/test/java/no/entur/uttu/model/FlexibleLineTest.java
@@ -25,6 +25,7 @@ public class FlexibleLineTest {
     public void checkPersistable_whenTransportSubmodeNotSet_giveException() {
         FlexibleLine flexibleLine = new FlexibleLine();
         flexibleLine.setTransportMode(VehicleModeEnumeration.BUS);
+        flexibleLine.setBookingArrangement(new BookingArrangement());
         assertCheckPersistableFails(flexibleLine);
     }
 
@@ -33,6 +34,7 @@ public class FlexibleLineTest {
     public void checkPersistable_whenTransportModeNotSet_giveException() {
         FlexibleLine flexibleLine = new FlexibleLine();
         flexibleLine.setTransportSubmode(VehicleSubmodeEnumeration.CAR_TRANSPORT_RAIL_SERVICE);
+        flexibleLine.setBookingArrangement(new BookingArrangement());
         assertCheckPersistableFails(flexibleLine);
     }
 
@@ -42,6 +44,7 @@ public class FlexibleLineTest {
         FlexibleLine flexibleLine = new FlexibleLine();
         flexibleLine.setTransportMode(VehicleModeEnumeration.BUS);
         flexibleLine.setTransportSubmode(VehicleSubmodeEnumeration.CAR_TRANSPORT_RAIL_SERVICE);
+        flexibleLine.setBookingArrangement(new BookingArrangement());
         assertCheckPersistableFails(flexibleLine);
     }
 
@@ -50,7 +53,16 @@ public class FlexibleLineTest {
         FlexibleLine flexibleLine = new FlexibleLine();
         flexibleLine.setTransportMode(VehicleModeEnumeration.BUS);
         flexibleLine.setTransportSubmode(VehicleSubmodeEnumeration.AIRPORT_LINK_BUS);
+        flexibleLine.setBookingArrangement(new BookingArrangement());
         flexibleLine.checkPersistable();
+    }
+
+    @Test
+    public void checkPersistable_whenMissingBookingInformation_giveException() {
+        FlexibleLine flexibleLine = new FlexibleLine();
+        flexibleLine.setTransportMode(VehicleModeEnumeration.BUS);
+        flexibleLine.setTransportSubmode(VehicleSubmodeEnumeration.AIRPORT_LINK_BUS);
+        assertCheckPersistableFails(flexibleLine);
     }
 
 

--- a/src/test/java/no/entur/uttu/model/FlexibleLineTest.java
+++ b/src/test/java/no/entur/uttu/model/FlexibleLineTest.java
@@ -17,6 +17,8 @@ package no.entur.uttu.model;
 
 import org.junit.Test;
 
+import java.util.List;
+
 import static no.entur.uttu.model.ModelTestUtil.assertCheckPersistableFails;
 
 public class FlexibleLineTest {
@@ -58,12 +60,35 @@ public class FlexibleLineTest {
     }
 
     @Test
+    public void checkPersistable_whenBookingInformationOnJourneyPattern_success() {
+        FlexibleLine flexibleLine = new FlexibleLine();
+        flexibleLine.setTransportMode(VehicleModeEnumeration.BUS);
+        flexibleLine.setTransportSubmode(VehicleSubmodeEnumeration.AIRPORT_LINK_BUS);
+        JourneyPattern journeyPattern = JourneyPatternTest.validJourneyPattern();
+        journeyPattern.getPointsInSequence().get(0).setBookingArrangement(new BookingArrangement());
+        flexibleLine.setJourneyPatterns(List.of(journeyPattern));
+        flexibleLine.checkPersistable();
+    }
+
+    @Test
+    public void checkPersistable_whenBookingInformationOnServiceJourney_success() {
+        FlexibleLine flexibleLine = new FlexibleLine();
+        flexibleLine.setTransportMode(VehicleModeEnumeration.BUS);
+        flexibleLine.setTransportSubmode(VehicleSubmodeEnumeration.AIRPORT_LINK_BUS);
+        flexibleLine.setOperatorRef("TST:Operator:1");
+        JourneyPattern journeyPattern = JourneyPatternTest.validJourneyPattern();
+        ServiceJourney serviceJourney = ServiceJourneyTest.validServiceJourney();
+        serviceJourney.setBookingArrangement(new BookingArrangement());
+        journeyPattern.setServiceJourneys(List.of(serviceJourney));
+        flexibleLine.setJourneyPatterns(List.of(journeyPattern));
+        flexibleLine.checkPersistable();
+    }
+
+    @Test
     public void checkPersistable_whenMissingBookingInformation_giveException() {
         FlexibleLine flexibleLine = new FlexibleLine();
         flexibleLine.setTransportMode(VehicleModeEnumeration.BUS);
         flexibleLine.setTransportSubmode(VehicleSubmodeEnumeration.AIRPORT_LINK_BUS);
         assertCheckPersistableFails(flexibleLine);
     }
-
-
 }

--- a/src/test/java/no/entur/uttu/model/FlexibleLineTest.java
+++ b/src/test/java/no/entur/uttu/model/FlexibleLineTest.java
@@ -89,6 +89,10 @@ public class FlexibleLineTest {
         FlexibleLine flexibleLine = new FlexibleLine();
         flexibleLine.setTransportMode(VehicleModeEnumeration.BUS);
         flexibleLine.setTransportSubmode(VehicleSubmodeEnumeration.AIRPORT_LINK_BUS);
+        JourneyPattern journeyPattern = JourneyPatternTest.validJourneyPattern();
+        ServiceJourney serviceJourney = ServiceJourneyTest.validServiceJourney();
+        journeyPattern.setServiceJourneys(List.of(serviceJourney));
+        flexibleLine.setJourneyPatterns(List.of(journeyPattern));
         assertCheckPersistableFails(flexibleLine);
     }
 

--- a/src/test/java/no/entur/uttu/model/FlexibleLineTest.java
+++ b/src/test/java/no/entur/uttu/model/FlexibleLineTest.java
@@ -27,7 +27,7 @@ public class FlexibleLineTest {
     public void checkPersistable_whenTransportSubmodeNotSet_giveException() {
         FlexibleLine flexibleLine = new FlexibleLine();
         flexibleLine.setTransportMode(VehicleModeEnumeration.BUS);
-        flexibleLine.setBookingArrangement(new BookingArrangement());
+        flexibleLine.setBookingArrangement(validBookingArrangement());
         assertCheckPersistableFails(flexibleLine);
     }
 
@@ -36,7 +36,7 @@ public class FlexibleLineTest {
     public void checkPersistable_whenTransportModeNotSet_giveException() {
         FlexibleLine flexibleLine = new FlexibleLine();
         flexibleLine.setTransportSubmode(VehicleSubmodeEnumeration.CAR_TRANSPORT_RAIL_SERVICE);
-        flexibleLine.setBookingArrangement(new BookingArrangement());
+        flexibleLine.setBookingArrangement(validBookingArrangement());
         assertCheckPersistableFails(flexibleLine);
     }
 
@@ -46,7 +46,7 @@ public class FlexibleLineTest {
         FlexibleLine flexibleLine = new FlexibleLine();
         flexibleLine.setTransportMode(VehicleModeEnumeration.BUS);
         flexibleLine.setTransportSubmode(VehicleSubmodeEnumeration.CAR_TRANSPORT_RAIL_SERVICE);
-        flexibleLine.setBookingArrangement(new BookingArrangement());
+        flexibleLine.setBookingArrangement(validBookingArrangement());
         assertCheckPersistableFails(flexibleLine);
     }
 
@@ -55,7 +55,7 @@ public class FlexibleLineTest {
         FlexibleLine flexibleLine = new FlexibleLine();
         flexibleLine.setTransportMode(VehicleModeEnumeration.BUS);
         flexibleLine.setTransportSubmode(VehicleSubmodeEnumeration.AIRPORT_LINK_BUS);
-        flexibleLine.setBookingArrangement(new BookingArrangement());
+        flexibleLine.setBookingArrangement(validBookingArrangement());
         flexibleLine.checkPersistable();
     }
 
@@ -65,7 +65,7 @@ public class FlexibleLineTest {
         flexibleLine.setTransportMode(VehicleModeEnumeration.BUS);
         flexibleLine.setTransportSubmode(VehicleSubmodeEnumeration.AIRPORT_LINK_BUS);
         JourneyPattern journeyPattern = JourneyPatternTest.validJourneyPattern();
-        journeyPattern.getPointsInSequence().get(0).setBookingArrangement(new BookingArrangement());
+        journeyPattern.getPointsInSequence().get(0).setBookingArrangement(validBookingArrangement());
         flexibleLine.setJourneyPatterns(List.of(journeyPattern));
         flexibleLine.checkPersistable();
     }
@@ -78,7 +78,7 @@ public class FlexibleLineTest {
         flexibleLine.setOperatorRef("TST:Operator:1");
         JourneyPattern journeyPattern = JourneyPatternTest.validJourneyPattern();
         ServiceJourney serviceJourney = ServiceJourneyTest.validServiceJourney();
-        serviceJourney.setBookingArrangement(new BookingArrangement());
+        serviceJourney.setBookingArrangement(validBookingArrangement());
         journeyPattern.setServiceJourneys(List.of(serviceJourney));
         flexibleLine.setJourneyPatterns(List.of(journeyPattern));
         flexibleLine.checkPersistable();
@@ -90,5 +90,11 @@ public class FlexibleLineTest {
         flexibleLine.setTransportMode(VehicleModeEnumeration.BUS);
         flexibleLine.setTransportSubmode(VehicleSubmodeEnumeration.AIRPORT_LINK_BUS);
         assertCheckPersistableFails(flexibleLine);
+    }
+
+    private BookingArrangement validBookingArrangement() {
+        BookingArrangement bookingArrangement = new BookingArrangement();
+        bookingArrangement.setBookWhen(PurchaseWhenEnumeration.DAY_OF_TRAVEL_ONLY);
+        return bookingArrangement;
     }
 }

--- a/src/test/java/no/entur/uttu/model/FlexibleLineTest.java
+++ b/src/test/java/no/entur/uttu/model/FlexibleLineTest.java
@@ -89,6 +89,14 @@ public class FlexibleLineTest {
         FlexibleLine flexibleLine = new FlexibleLine();
         flexibleLine.setTransportMode(VehicleModeEnumeration.BUS);
         flexibleLine.setTransportSubmode(VehicleSubmodeEnumeration.AIRPORT_LINK_BUS);
+        assertCheckPersistableFails(flexibleLine);
+    }
+
+    @Test
+    public void checkPersistable_whenMissingBookingInformationInHierarchy_giveException() {
+        FlexibleLine flexibleLine = new FlexibleLine();
+        flexibleLine.setTransportMode(VehicleModeEnumeration.BUS);
+        flexibleLine.setTransportSubmode(VehicleSubmodeEnumeration.AIRPORT_LINK_BUS);
         JourneyPattern journeyPattern = JourneyPatternTest.validJourneyPattern();
         ServiceJourney serviceJourney = ServiceJourneyTest.validServiceJourney();
         journeyPattern.setServiceJourneys(List.of(serviceJourney));

--- a/src/test/java/no/entur/uttu/model/JourneyPatternTest.java
+++ b/src/test/java/no/entur/uttu/model/JourneyPatternTest.java
@@ -52,6 +52,13 @@ public class JourneyPatternTest {
     }
 
     @Test
+    public void checkPersistable_destinationDisplayOnLastStopPointsInJourneyPattern_givesException() {
+        JourneyPattern jp = validJourneyPattern();
+        jp.getPointsInSequence().get(jp.getPointsInSequence().size() - 1).setDestinationDisplay(new DestinationDisplay());
+        assertCheckPersistableFails(jp);
+    }
+
+    @Test
     public void setPointsInSequence_assignsOrder() {
         JourneyPattern journeyPattern = new JourneyPattern();
 

--- a/src/test/java/no/entur/uttu/model/JourneyPatternTest.java
+++ b/src/test/java/no/entur/uttu/model/JourneyPatternTest.java
@@ -72,7 +72,7 @@ public class JourneyPatternTest {
     }
 
 
-    private JourneyPattern validJourneyPattern() {
+    protected static JourneyPattern validJourneyPattern() {
         JourneyPattern journeyPattern = new JourneyPattern();
 
         StopPointInJourneyPattern firstPoint = new StopPointInJourneyPattern();

--- a/src/test/java/no/entur/uttu/model/NoticeTest.java
+++ b/src/test/java/no/entur/uttu/model/NoticeTest.java
@@ -1,0 +1,19 @@
+package no.entur.uttu.model;
+
+import org.junit.Test;
+
+import static no.entur.uttu.model.ModelTestUtil.assertCheckPersistableFails;
+
+public class NoticeTest {
+
+    @Test
+    public void checkPersistable_notice_success() {
+        new Notice().withText("This is a good notice.").checkPersistable();
+    }
+
+    @Test
+    public void checkPersistable_noticeWithoutText_givesException() {
+        assertCheckPersistableFails(new Notice());
+        assertCheckPersistableFails(new Notice().withText(""));
+    }
+}

--- a/src/test/java/no/entur/uttu/model/ServiceJourneyTest.java
+++ b/src/test/java/no/entur/uttu/model/ServiceJourneyTest.java
@@ -99,7 +99,7 @@ public class ServiceJourneyTest {
         assertCheckPersistableFails(serviceJourney);
     }
 
-    private ServiceJourney validServiceJourney() {
+    protected static ServiceJourney validServiceJourney() {
         ServiceJourney serviceJourney = new ServiceJourney();
         serviceJourney.setJourneyPattern(createJP(2));
 
@@ -109,7 +109,7 @@ public class ServiceJourneyTest {
         return serviceJourney;
     }
 
-    private JourneyPattern createJP(int size) {
+    private static JourneyPattern createJP(int size) {
         JourneyPattern journeyPattern = new JourneyPattern();
         journeyPattern.setLine(new FlexibleLine());
         journeyPattern.getLine().setOperatorRef("34");
@@ -121,7 +121,7 @@ public class ServiceJourneyTest {
         return journeyPattern;
     }
 
-    private TimetabledPassingTime passingTime(LocalTime arrivalTime, LocalTime departureTime) {
+    private static TimetabledPassingTime passingTime(LocalTime arrivalTime, LocalTime departureTime) {
         TimetabledPassingTime passingTime = new TimetabledPassingTime();
         passingTime.setArrivalTime(arrivalTime);
         passingTime.setDepartureTime(departureTime);

--- a/src/test/java/no/entur/uttu/model/TimetabledPassingTimeTest.java
+++ b/src/test/java/no/entur/uttu/model/TimetabledPassingTimeTest.java
@@ -64,6 +64,11 @@ public class TimetabledPassingTimeTest {
     }
 
     @Test
+    public void checkPersistable_arrivalEqualsDeparture_givesException() {
+        assertCheckPersistableFails(new TimetabledPassingTime().withArrivalTime(T0).withDepartureTime(T0));
+    }
+
+    @Test
     public void checkBeforeOther_departureOneAfterDepartureTwo_givesException() {
         TimetabledPassingTime one = new TimetabledPassingTime().withDepartureTime(T1).withDepartureDayOffset(1);
         TimetabledPassingTime two = new TimetabledPassingTime().withDepartureTime(T0).withDepartureDayOffset(1);

--- a/src/test/java/no/entur/uttu/model/TimetabledPassingTimeTest.java
+++ b/src/test/java/no/entur/uttu/model/TimetabledPassingTimeTest.java
@@ -39,7 +39,7 @@ public class TimetabledPassingTimeTest {
 
     @Test
     public void checkPersistable_maxFieldsSet_success() {
-        new TimetabledPassingTime().withArrivalTime(T0).withLatestArrivalTime(T0).withEarliestDepartureTime(T0).withDepartureTime(T0).checkPersistable();
+        new TimetabledPassingTime().withEarliestDepartureTime(T0).withDepartureTime(T0).checkPersistable();
         new TimetabledPassingTime().withArrivalTime(T0).withLatestArrivalTime(T1).withEarliestDepartureTime(T2).withDepartureTime(T3).checkPersistable();
 
         new TimetabledPassingTime().withArrivalTime(T3).withArrivalDayOffset(0).withLatestArrivalTime(T2).withLatestArrivalDayOffset(1).withEarliestDepartureTime(T1)


### PR DESCRIPTION
- [x] Notice without text (https://toil.kitemaker.co/cKEZAv-entur-ror/c1rxul-RoR_-_Development/items/1606)
- [x] Destination display on last stop in pattern (https://toil.kitemaker.co/cKEZAv-entur-ror/c1rxul-RoR_-_Development/items/1610)
- [x] Identical arrival and departure times (https://toil.kitemaker.co/cKEZAv-entur-ror/c1rxul-RoR_-_Development/items/1607)
- [x] Id and version in FlexibleServiceProperties upon export (https://toil.kitemaker.co/cKEZAv-entur-ror/c1rxul-RoR_-_Development/items/1608)
- [x] Validate booking (https://toil.kitemaker.co/cKEZAv-entur-ror/c1rxul-RoR_-_Development/items/1611)