### PR TITLE
Export produced incorrect refs for "fixed" lines in notice assignments

### DIFF
--- a/src/main/java/no/entur/uttu/export/netex/producer/line/LineProducer.java
+++ b/src/main/java/no/entur/uttu/export/netex/producer/line/LineProducer.java
@@ -28,6 +28,7 @@ import org.rutebanken.netex.model.BookingAccessEnumeration;
 import org.rutebanken.netex.model.BookingMethodEnumeration;
 import org.rutebanken.netex.model.FlexibleLineRefStructure;
 import org.rutebanken.netex.model.FlexibleLineTypeEnumeration;
+import org.rutebanken.netex.model.LineRefStructure;
 import org.rutebanken.netex.model.Line_VersionStructure;
 import org.rutebanken.netex.model.NoticeAssignment;
 import org.rutebanken.netex.model.PurchaseMomentEnumeration;
@@ -56,7 +57,7 @@ public class LineProducer {
         return lineVisitor.getLine();
     }
 
-    protected void mapCommon(no.entur.uttu.model.Line local, org.rutebanken.netex.model.Line_VersionStructure netex, List<NoticeAssignment> noticeAssignments, NetexExportContext context) {
+    protected void mapCommon(no.entur.uttu.model.Line local, org.rutebanken.netex.model.Line_VersionStructure netex, NetexExportContext context) {
         netex.setName(objectFactory.createMultilingualString(local.getName()));
         netex.setPrivateCode(objectFactory.createPrivateCodeStructure(local.getPrivateCode()));
 
@@ -73,8 +74,6 @@ public class LineProducer {
 
         netex.setRepresentedByGroupRef(objectFactory.createGroupOfLinesRefStructure(local.getNetwork().getNetexId()));
         context.networks.add(local.getNetwork());
-
-        noticeAssignments.addAll(objectFactory.createNoticeAssignments(local, FlexibleLineRefStructure.class, local.getNotices(), context));
         context.notices.addAll(local.getNotices());
     }
 
@@ -108,7 +107,8 @@ public class LineProducer {
         @Override
         public void visitFixedLine(FixedLine fixedLine) {
             org.rutebanken.netex.model.Line netexLine = new org.rutebanken.netex.model.Line();
-            mapCommon(fixedLine, netexLine, noticeAssignments, context);
+            noticeAssignments.addAll(objectFactory.createNoticeAssignments(fixedLine, LineRefStructure.class, fixedLine.getNotices(), context));
+            mapCommon(fixedLine, netexLine, context);
             line = NetexIdProducer.copyIdAndVersion(netexLine, fixedLine);
         }
 
@@ -116,7 +116,8 @@ public class LineProducer {
         public void visitFlexibleLine(FlexibleLine flexibleLine) {
             org.rutebanken.netex.model.FlexibleLine netexLine = new org.rutebanken.netex.model.FlexibleLine();
             netexLine.setFlexibleLineType(objectFactory.mapEnum(flexibleLine.getFlexibleLineType(), FlexibleLineTypeEnumeration.class));
-            mapCommon(flexibleLine, netexLine, noticeAssignments, context);
+            noticeAssignments.addAll(objectFactory.createNoticeAssignments(flexibleLine, FlexibleLineRefStructure.class, flexibleLine.getNotices(), context));
+            mapCommon(flexibleLine, netexLine, context);
             mapBookingArrangements(flexibleLine.getBookingArrangement(), netexLine);
             line = NetexIdProducer.copyIdAndVersion(netexLine, flexibleLine);
         }

--- a/src/test/groovy/no/entur/uttu/graphql/AbstractFixedLinesGraphQLIntegrationTest.groovy
+++ b/src/test/groovy/no/entur/uttu/graphql/AbstractFixedLinesGraphQLIntegrationTest.groovy
@@ -112,6 +112,7 @@ abstract class AbstractFixedLinesGraphQLIntegrationTest extends AbstractGraphQLR
                 "transportSubmode": "localBus",
                 "networkRef": "$networkId",
                 "operatorRef": "22",
+                "notices": [{"text": "Dette er en fiktiv linje."}],
                 "journeyPatterns": [
                   {
                     "pointsInSequence": [

--- a/src/test/groovy/no/entur/uttu/graphql/ExportFixedLineGraphQLIntegrationTest.groovy
+++ b/src/test/groovy/no/entur/uttu/graphql/ExportFixedLineGraphQLIntegrationTest.groovy
@@ -1,0 +1,64 @@
+package no.entur.uttu.graphql
+
+import io.restassured.response.ValidatableResponse
+import no.entur.uttu.model.job.ExportStatusEnumeration
+import org.junit.Test
+
+import java.time.LocalDate
+
+import static org.hamcrest.Matchers.equalTo
+import static org.hamcrest.Matchers.isEmptyOrNullString
+import static org.hamcrest.Matchers.not
+import static org.hamcrest.Matchers.startsWith
+
+class ExportFixedLineGraphQLIntegrationTest extends AbstractFixedLinesGraphQLIntegrationTest {
+
+    @Test
+    void createExport() {
+        String name = "Fiktiv linje";
+        ValidatableResponse fixedLineResponse = createFixedLine(name);
+
+        String createExportQuery = """
+ mutation export(\$export: ExportInput!) {
+  export(input: \$export) {
+    id
+    name
+    exportStatus
+    downloadUrl
+    messages {
+        message
+        severity
+    }
+  }
+  }
+         """
+
+        LocalDate today = LocalDate.now()
+
+        String lineRef = fixedLineResponse.extract().body().path("data.mutateFixedLine.id")
+        String variables = """    
+{
+  "export": {
+    "name": "$name",
+    "lineAssociations":[{ "lineRef": "$lineRef" }]
+  }
+}
+        """
+
+        ValidatableResponse rsp = executeGraphQL(createExportQuery, variables)
+                .body("data.export.id", startsWith("TST:Export"))
+                .body("data.export.name", equalTo(name))
+                .body("data.export.exportStatus", equalTo(ExportStatusEnumeration.SUCCESS.value()))
+                .body("data.export.downloadUrl", startsWith("tst/export/"))
+
+        String downloadUrl = rsp.extract().body().path("data.export.downloadUrl")
+        authenticatedRequestSpecification()
+                .port(port)
+                .when()
+                .get("/services/flexible-lines/" + downloadUrl)
+                .then()
+                .log().body()
+                .statusCode(200)
+                .body(not(isEmptyOrNullString()))
+    }
+}


### PR DESCRIPTION
https://toil.kitemaker.co/cKEZAv-entur-ror/c1rxul-RoR_-_Development/items/1604

All notice assignments used "FlexibleLine" in the netex id ref, also for regular "Line". This bug was introduced when we added support for regular lines in uttu. The fix moves the production of notice assignemtns out of the common mapping logic into the visitor methods for the respective line types.

From export produced by new integration test:

```
                    <noticeAssignments>
                        <NoticeAssignment order="2" version="1" id="TST:NoticeAssignment:1">
                            <NoticeRef ref="TST:Notice:7b735783-73d0-46c3-8f9d-d4f202225cb4"/>
                            <NoticedObjectRef xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="LineRefStructure" ref="TST:Line:0bd86b87-7574-4bf0-867e-38b873eda5b3" version="0"/>
                        </NoticeAssignment>
                    </noticeAssignments>
```