### PR TITLE
fix: hibernate maps LocalTime to TIME

### DIFF
--- a/src/main/resources/db/migration/V14__Use_time_no_timestamp_in_timetable.sql
+++ b/src/main/resources/db/migration/V14__Use_time_no_timestamp_in_timetable.sql
@@ -3,3 +3,6 @@ ALTER TABLE timetabled_passing_time
     ALTER COLUMN departure_time TYPE time without time zone,
     ALTER COLUMN latest_arrival_time TYPE time without time zone,
     ALTER COLUMN earliest_departure_time TYPE time without time zone;
+
+ALTER TABLE booking_arrangement
+    ALTER COLUMN latest_booking_time TYPE time without time zone;

--- a/src/main/resources/db/migration/V14__Use_time_no_timestamp_in_timetable.sql
+++ b/src/main/resources/db/migration/V14__Use_time_no_timestamp_in_timetable.sql
@@ -1,0 +1,5 @@
+ALTER TABLE timetabled_passing_time
+    ALTER COLUMN arrival_time TYPE time without time zone,
+    ALTER COLUMN departure_time TYPE time without time zone,
+    ALTER COLUMN latest_arrival_time TYPE time without time zone,
+    ALTER COLUMN earliest_departure_time TYPE time without time zone;


### PR DESCRIPTION
https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#_localtime

The incorrect db type caused SQL error when moving integration tests to use testcontainers, possibly due to the testcontainers jdbc driver or the hibernate dialect being less lenient on type casting?

```
ERROR: invalid input syntax for type timestamp: "16:00:00+01"
```
