### PR TITLE
Add validation for combinations of regular passing times and time windows

### DIFF
--- a/src/main/java/no/entur/uttu/model/TimetabledPassingTime.java
+++ b/src/main/java/no/entur/uttu/model/TimetabledPassingTime.java
@@ -212,12 +212,20 @@ public class TimetabledPassingTime extends ProviderEntity {
      * @param other the other TimetabledPassingTime
      */
     public void checkBeforeOther(TimetabledPassingTime other) {
+
+        // Validate regular passing times
         Preconditions.checkArgument(ValidationHelper.isNotAfter(departureTime, departureDayOffset, other.departureTime, other.departureDayOffset), "%s departureTime cannot be after next elements (%s) departureTime", identity(), other.identity());
         Preconditions.checkArgument(ValidationHelper.isNotAfter(departureTime, departureDayOffset, other.arrivalTime, other.arrivalDayOffset), "%s departureTime cannot be after next elements (%s) arrivalTime", identity(), other.identity());
         Preconditions.checkArgument(ValidationHelper.isNotAfter(arrivalTime, arrivalDayOffset, other.arrivalTime, other.arrivalDayOffset), "%s arrivalTime cannot be after next elements (%s) arrivalTime", identity(), other.identity());
         Preconditions.checkArgument(ValidationHelper.isNotAfter(arrivalTime, arrivalDayOffset, other.departureTime, other.departureDayOffset), "%s arrivalTime cannot be after next elements (%s) departureTime", identity(), other.identity());
+
+        // Validate combinations of time windows
         Preconditions.checkArgument(ValidationHelper.isNotAfter(latestArrivalTime, latestArrivalDayOffset, other.latestArrivalTime, other.latestArrivalDayOffset), "%s latestArrivalTime cannot be after later next elements (%s) latestArrivalTime", identity(), other.identity());
         Preconditions.checkArgument(ValidationHelper.isNotAfter(earliestDepartureTime, earliestDepartureDayOffset, other.earliestDepartureTime, other.earliestDepartureDayOffset), "%s earliestDepartureTime cannot be after later next elements (%s) earliestDepartureTime", identity(), other.identity());
+
+        // Validate time window in combination with regular passing time
+        Preconditions.checkArgument(ValidationHelper.isNotAfter(latestArrivalTime, latestArrivalDayOffset, other.arrivalTime, other.arrivalDayOffset), "%s latestArrivalTime cannot be after next element (%s) arrivalTime", identity(), other.identity());
+        Preconditions.checkArgument(ValidationHelper.isNotAfter(departureTime, departureDayOffset, other.earliestDepartureTime, other.earliestDepartureDayOffset), "%s departureTime cannot be after next element (%s) earliestDepartureTime", identity(), other.identity());
     }
 
     public static class MultilingualString {

--- a/src/test/java/no/entur/uttu/model/ServiceJourneyTest.java
+++ b/src/test/java/no/entur/uttu/model/ServiceJourneyTest.java
@@ -99,11 +99,83 @@ public class ServiceJourneyTest {
         assertCheckPersistableFails(serviceJourney);
     }
 
+    @Test
+    public void checkPersistable_whenFixedArrivalBeforeEndOfTimeWindowOfPreviousStop_thenThrowException() {
+        ServiceJourney serviceJourney = validServiceJourney();
+
+        serviceJourney.setPassingTimes(
+                List.of(
+                        // Time window 10:00 - 11:00
+                        timeWindowPassingTime(LocalTime.of(10, 0), LocalTime.of(11, 0)),
+
+                        // Arrival at 10:30
+                        passingTime(LocalTime.of(10, 30), null)
+                )
+        );
+
+        assertCheckPersistableFails(serviceJourney);
+    }
+
+    @Test
+    public void checkPersistable_whenFixedArrivalIsAfterEndOfTimeWindowOfNextStop_thenSuccess() {
+        ServiceJourney serviceJourney = validServiceJourney();
+
+        serviceJourney.setPassingTimes(
+                List.of(
+                        // Time window 10:00 - 11:00
+                        timeWindowPassingTime(LocalTime.of(10, 0), LocalTime.of(11, 0)),
+
+                        // Arrival at 11:15
+                        passingTime(LocalTime.of(11, 15), null)
+                )
+        );
+
+        serviceJourney.checkPersistable();
+    }
+
+    @Test
+    public void checkPersistable_whenFixedDepartureIsAfterStartOfTimeWindowOfNextStop_thenThrowException() {
+        ServiceJourney serviceJourney = validServiceJourney();
+
+        serviceJourney.setPassingTimes(
+                List.of(
+                        // Departs at 10:15
+                        passingTime(null, LocalTime.of(10, 15)),
+
+                        // Time window 10:00 - 11:00
+                        timeWindowPassingTime(LocalTime.of(10, 0), LocalTime.of(11, 0))
+                )
+        );
+
+        assertCheckPersistableFails(serviceJourney);
+    }
+
+    @Test
+    public void checkPersistable_whenFixedDepartureIsBeforeStartOfTimeWindowOfNextStop_thenSuccess() {
+        ServiceJourney serviceJourney = validServiceJourney();
+
+        serviceJourney.setPassingTimes(
+                List.of(
+                        // Departs at 09:45
+                        passingTime(null, LocalTime.of(9, 45)),
+
+                        // Time window 10:00 - 11:00
+                        timeWindowPassingTime(LocalTime.of(10, 0), LocalTime.of(11, 0))
+                )
+        );
+
+        serviceJourney.checkPersistable();
+    }
+
     protected static ServiceJourney validServiceJourney() {
         ServiceJourney serviceJourney = new ServiceJourney();
         serviceJourney.setJourneyPattern(createJP(2));
 
-        List<TimetabledPassingTime> passingTimes = Arrays.asList(passingTime(null, LocalTime.of(10, 0)), passingTime(LocalTime.of(11, 0), null));
+        List<TimetabledPassingTime> passingTimes = Arrays.asList(
+                passingTime(null, LocalTime.of(10, 0)),
+                passingTime(LocalTime.of(11, 0), null)
+        );
+
         serviceJourney.setPassingTimes(passingTimes);
 
         return serviceJourney;
@@ -122,9 +194,14 @@ public class ServiceJourneyTest {
     }
 
     private static TimetabledPassingTime passingTime(LocalTime arrivalTime, LocalTime departureTime) {
-        TimetabledPassingTime passingTime = new TimetabledPassingTime();
-        passingTime.setArrivalTime(arrivalTime);
-        passingTime.setDepartureTime(departureTime);
-        return passingTime;
+        return new TimetabledPassingTime()
+                .withArrivalTime(arrivalTime)
+                .withDepartureTime(departureTime);
+    }
+
+    private static TimetabledPassingTime timeWindowPassingTime(LocalTime earliestDepartureTime, LocalTime latestArrivalTime) {
+        return new TimetabledPassingTime()
+                .withEarliestDepartureTime(earliestDepartureTime)
+                .withLatestArrivalTime(latestArrivalTime);
     }
 }


### PR DESCRIPTION
We currently have validation for the following

* No overlap in regular passing times, e.g. no departure from stop N after arrival at stop N+1, and no departure before arrival at the same stop, and so on.
* No overlap in time windows, e.g. no earliest departure after latest arrival at the same stop, and no overlapping time windows from one stop to the next.

What was missing was validation between regular passing time and time window. So this PR adds:

* There should be no overlap between time window in one stop and regular passing times in previous or next stop.