### PR TITLE
Map operating periods to operating day refs

### DIFF
--- a/src/main/java/no/entur/uttu/export/netex/producer/NetexObjectFactory.java
+++ b/src/main/java/no/entur/uttu/export/netex/producer/NetexObjectFactory.java
@@ -453,7 +453,8 @@ public class NetexObjectFactory {
     NetexExportContext context,
     Collection<DayType> dayTypes,
     Collection<DayTypeAssignment> dayTypeAssignments,
-    Collection<OperatingPeriod> operatingPeriods
+    Collection<OperatingPeriod> operatingPeriods,
+    Collection<OperatingDay> operatingDays
   ) {
     String frameId = NetexIdProducer.generateId(ServiceCalendarFrame.class, context);
 
@@ -487,13 +488,23 @@ public class NetexObjectFactory {
         .sort(Comparator.comparing(OperatingPeriod_VersionStructure::getFromDate));
     }
 
+    OperatingDaysInFrame_RelStructure operatingDaysInFrameRelStructure = null;
+    if (!CollectionUtils.isEmpty(operatingDays)) {
+      operatingDaysInFrameRelStructure = new OperatingDaysInFrame_RelStructure();
+      operatingDaysInFrameRelStructure.getOperatingDay().addAll(operatingDays);
+      operatingDaysInFrameRelStructure
+        .getOperatingDay()
+        .sort(Comparator.comparing(OperatingDay_VersionStructure::getCalendarDate));
+    }
+
     return objectFactory
       .createServiceCalendarFrame()
       .withVersion(VERSION_ONE)
       .withId(frameId)
       .withDayTypes(dayTypesStruct)
       .withDayTypeAssignments(dayTypeAssignmentsInFrameRelStructure)
-      .withOperatingPeriods(operatingPeriodsInFrameRelStructure);
+      .withOperatingPeriods(operatingPeriodsInFrameRelStructure)
+      .withOperatingDays(operatingDaysInFrameRelStructure);
   }
 
   public JAXBElement<AvailabilityCondition> createAvailabilityCondition(

--- a/src/main/java/no/entur/uttu/export/netex/producer/common/MappedOperatingPeriod.java
+++ b/src/main/java/no/entur/uttu/export/netex/producer/common/MappedOperatingPeriod.java
@@ -1,0 +1,27 @@
+package no.entur.uttu.export.netex.producer.common;
+
+import java.util.List;
+import org.rutebanken.netex.model.OperatingDay;
+import org.rutebanken.netex.model.OperatingPeriod;
+
+public class MappedOperatingPeriod {
+
+  private final OperatingPeriod operatingPeriod;
+  private final List<OperatingDay> operatingDays;
+
+  public MappedOperatingPeriod(
+    OperatingPeriod operatingPeriod,
+    List<OperatingDay> operatingDays
+  ) {
+    this.operatingPeriod = operatingPeriod;
+    this.operatingDays = operatingDays;
+  }
+
+  public OperatingPeriod getOperatingPeriod() {
+    return operatingPeriod;
+  }
+
+  public List<OperatingDay> getOperatingDays() {
+    return operatingDays;
+  }
+}


### PR DESCRIPTION
Background: In order to avoid confusion wrt the semantics of the time portion of dateTime in fromDate  and toDate of OperatingPeriod, use a ref to operating day instead which can refer to calendar date without time specification.

Example output:

```xml
<operatingDays>
    <OperatingDay version="0" id="ENT:OperatingDay:1">
        <CalendarDate>2023-04-17</CalendarDate>
    </OperatingDay>
    <OperatingDay version="0" id="ENT:OperatingDay:2">
        <CalendarDate>2023-04-18</CalendarDate>
    </OperatingDay>
</operatingDays>
<operatingPeriods>
    <OperatingPeriod version="0" id="ENT:OperatingPeriod:1">
        <FromOperatingDayRef ref="ENT:OperatingDay:1"/>
        <ToOperatingDayRef ref="ENT:OperatingDay:2"/>
    </OperatingPeriod>
</operatingPeriods>
<dayTypeAssignments>
    <DayTypeAssignment order="1" version="0" id="ENT:DayTypeAssignment:1">
        <OperatingPeriodRef ref="ENT:OperatingPeriod:1" version="0"/>
        <DayTypeRef ref="ENT:DayType:7f25227a-4cee-44bb-ae14-ba0612c90414" version="0"/>
        <isAvailable>true</isAvailable>
    </DayTypeAssignment>
</dayTypeAssignments>
```

Note: this PR assumes the Nordic NeTEx profile will change the cardinality of `EarliestTime` and `DayLength` to `0:1` (i.e. they will become optional).