### PR TITLE
fix: remove unneeded attributes from NoticedObjectRef element in export

### DIFF
--- a/src/main/java/no/entur/uttu/export/netex/producer/line/JourneyPatternProducer.java
+++ b/src/main/java/no/entur/uttu/export/netex/producer/line/JourneyPatternProducer.java
@@ -34,7 +34,6 @@ import org.rutebanken.netex.model.BookingAccessEnumeration;
 import org.rutebanken.netex.model.BookingArrangementsStructure;
 import org.rutebanken.netex.model.BookingMethodEnumeration;
 import org.rutebanken.netex.model.DestinationDisplayRefStructure;
-import org.rutebanken.netex.model.JourneyPatternRefStructure;
 import org.rutebanken.netex.model.NoticeAssignment;
 import org.rutebanken.netex.model.PointInLinkSequence_VersionedChildStructure;
 import org.rutebanken.netex.model.PointsInJourneyPattern_RelStructure;
@@ -43,7 +42,6 @@ import org.rutebanken.netex.model.PurchaseWhenEnumeration;
 import org.rutebanken.netex.model.RouteRefStructure;
 import org.rutebanken.netex.model.ScheduledStopPoint;
 import org.rutebanken.netex.model.ScheduledStopPointRefStructure;
-import org.rutebanken.netex.model.StopPointInJourneyPatternRefStructure;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -86,12 +84,7 @@ public class JourneyPatternProducer {
     );
 
     noticeAssignments.addAll(
-      objectFactory.createNoticeAssignments(
-        local,
-        JourneyPatternRefStructure.class,
-        local.getNotices(),
-        context
-      )
+      objectFactory.createNoticeAssignments(local, local.getNotices(), context)
     );
     context.notices.addAll(local.getNotices());
 
@@ -157,12 +150,7 @@ public class JourneyPatternProducer {
       );
 
     noticeAssignments.addAll(
-      objectFactory.createNoticeAssignments(
-        local,
-        StopPointInJourneyPatternRefStructure.class,
-        local.getNotices(),
-        context
-      )
+      objectFactory.createNoticeAssignments(local, local.getNotices(), context)
     );
     context.notices.addAll(local.getNotices());
 

--- a/src/main/java/no/entur/uttu/export/netex/producer/line/LineProducer.java
+++ b/src/main/java/no/entur/uttu/export/netex/producer/line/LineProducer.java
@@ -27,9 +27,7 @@ import no.entur.uttu.model.Line;
 import org.rutebanken.netex.model.AllVehicleModesOfTransportEnumeration;
 import org.rutebanken.netex.model.BookingAccessEnumeration;
 import org.rutebanken.netex.model.BookingMethodEnumeration;
-import org.rutebanken.netex.model.FlexibleLineRefStructure;
 import org.rutebanken.netex.model.FlexibleLineTypeEnumeration;
-import org.rutebanken.netex.model.LineRefStructure;
 import org.rutebanken.netex.model.Line_VersionStructure;
 import org.rutebanken.netex.model.NoticeAssignment;
 import org.rutebanken.netex.model.PurchaseMomentEnumeration;
@@ -152,12 +150,7 @@ public class LineProducer {
     public void visitFixedLine(FixedLine fixedLine) {
       org.rutebanken.netex.model.Line netexLine = new org.rutebanken.netex.model.Line();
       noticeAssignments.addAll(
-        objectFactory.createNoticeAssignments(
-          fixedLine,
-          LineRefStructure.class,
-          fixedLine.getNotices(),
-          context
-        )
+        objectFactory.createNoticeAssignments(fixedLine, fixedLine.getNotices(), context)
       );
       mapCommon(fixedLine, netexLine, context);
       line = NetexIdProducer.copyIdAndVersion(netexLine, fixedLine);
@@ -176,7 +169,6 @@ public class LineProducer {
       noticeAssignments.addAll(
         objectFactory.createNoticeAssignments(
           flexibleLine,
-          FlexibleLineRefStructure.class,
           flexibleLine.getNotices(),
           context
         )

--- a/src/main/java/no/entur/uttu/export/netex/producer/line/ServiceJourneyProducer.java
+++ b/src/main/java/no/entur/uttu/export/netex/producer/line/ServiceJourneyProducer.java
@@ -43,9 +43,7 @@ import org.rutebanken.netex.model.OperatorRefStructure;
 import org.rutebanken.netex.model.PointInJourneyPatternRefStructure;
 import org.rutebanken.netex.model.PurchaseMomentEnumeration;
 import org.rutebanken.netex.model.PurchaseWhenEnumeration;
-import org.rutebanken.netex.model.ServiceJourneyRefStructure;
 import org.rutebanken.netex.model.StopPointInJourneyPatternRefStructure;
-import org.rutebanken.netex.model.TimetabledPassingTimeRefStructure;
 import org.rutebanken.netex.model.TimetabledPassingTimes_RelStructure;
 import org.springframework.stereotype.Component;
 
@@ -111,12 +109,7 @@ public class ServiceJourneyProducer {
       );
 
     noticeAssignments.addAll(
-      objectFactory.createNoticeAssignments(
-        local,
-        ServiceJourneyRefStructure.class,
-        local.getNotices(),
-        context
-      )
+      objectFactory.createNoticeAssignments(local, local.getNotices(), context)
     );
     context.notices.addAll(local.getNotices());
 
@@ -181,12 +174,7 @@ public class ServiceJourneyProducer {
       : null;
 
     noticeAssignments.addAll(
-      objectFactory.createNoticeAssignments(
-        local,
-        TimetabledPassingTimeRefStructure.class,
-        local.getNotices(),
-        context
-      )
+      objectFactory.createNoticeAssignments(local, local.getNotices(), context)
     );
     context.notices.addAll(local.getNotices());
 


### PR DESCRIPTION
The attributes were added by the marshaller due to passing of subclass instances of VersionOfObjectRefStructure to the notice assignment object factory, which expected instances of VersionOfObjectRefStructure directly

![image (8)](https://github.com/entur/uttu/assets/231492/051a9987-a056-4430-89d6-7c94e777018e)


