### PR TITLE
fix: pad availability condition id with "_UTTU" to avoid id collision with other systems

### DIFF
--- a/src/main/java/no/entur/uttu/export/netex/producer/NetexIdProducer.java
+++ b/src/main/java/no/entur/uttu/export/netex/producer/NetexIdProducer.java
@@ -100,6 +100,10 @@ public class NetexIdProducer {
     return objectId.replaceFirst(getObjectIdPrefix(objectId), getIdPrefix(context));
   }
 
+  public static String updateIdSuffix(String objectId, String newSuffix) {
+    return objectId.replaceFirst(getObjectIdSuffix(objectId), newSuffix);
+  }
+
   public static String getObjectIdPrefix(String objectId) {
     return objectId.split(SEPARATOR)[0];
   }

--- a/src/main/java/no/entur/uttu/export/netex/producer/NetexObjectFactory.java
+++ b/src/main/java/no/entur/uttu/export/netex/producer/NetexObjectFactory.java
@@ -16,6 +16,7 @@
 package no.entur.uttu.export.netex.producer;
 
 import static no.entur.uttu.export.netex.producer.NetexIdProducer.getEntityName;
+import static no.entur.uttu.export.netex.producer.NetexIdProducer.getObjectIdSuffix;
 
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -495,6 +496,12 @@ public class NetexObjectFactory {
       AvailabilityCondition.class,
       context
     );
+
+    availabilityConditionId =
+      NetexIdProducer.updateIdSuffix(
+        availabilityConditionId,
+        getObjectIdSuffix(availabilityConditionId) + "_UTTU"
+      );
 
     AvailabilityCondition availabilityCondition = objectFactory
       .createAvailabilityCondition()


### PR DESCRIPTION
Similar change previously: https://github.com/entur/uttu/pull/116

Perhaps we should look for a more generic solution 🤔 

Solves WTK-1828