### PR TITLE
Add local-disk-blobstore Spring profile

### DIFF
--- a/src/main/java/no/entur/uttu/export/blob/LocalDiskBlobStoreService.java
+++ b/src/main/java/no/entur/uttu/export/blob/LocalDiskBlobStoreService.java
@@ -27,7 +27,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
-@Profile({ "local", "test" })
+@Profile({ "local", "test", "local-disk-blobstore" })
 public class LocalDiskBlobStoreService implements BlobStoreService {
 
   @Value("${blobstore.local.folder:files/blob}")


### PR DESCRIPTION
Define a Spring profile that enables the local disk blob store implementation.
This can be used for local testing with authentication enabled.
(The existing profile "local" enables also the local disk blob store implementation, but disable authentication.)