### PR TITLE
add AWS Secrets Manager related libraries for use in application configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,6 +270,18 @@
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
 
+        <!-- AWS: enable use of Secrets Manager as parameter source in configurations -->
+        <dependency>
+            <groupId>io.awspring.cloud</groupId>
+            <artifactId>spring-cloud-aws-starter-secrets-manager</artifactId>
+            <version>3.1.1</version>
+        </dependency>
+        <!-- AWS: acquire and refresh jdbc credentials from Secrets Manager in cloud environments -->
+        <dependency>
+            <groupId>com.amazonaws.secretsmanager</groupId>
+            <artifactId>aws-secretsmanager-jdbc</artifactId>
+            <version>2.0.2</version>
+        </dependency>
 
         <dependency>
             <groupId>org.junit.vintage</groupId>


### PR DESCRIPTION
 - **adds [`spring-cloud-aws-starter-secrets-manager`](https://docs.awspring.io/spring-cloud-aws/docs/3.1.1/reference/html/index.html#spring-cloud-aws-secrets-manager)** which allows referencing secrets maintained in AWS Secrets Manager as part of normal Spring Boot application configuration as config imports
 - **adds [`aws-secretsmanager-jdbc`](https://github.com/aws/aws-secretsmanager-jdbc)** which allows using credentials maintained in Secrets Manager as database connection parameters

**Motivation:**

In short, our AWS environment configuration relies on these libraries to keep secrets secret without inclusion in plaintext to project metafiles and also allow for keeping the configuration short :-)

Both of these libraries are visible in configuration only. As a pseudo example, these are utilized like so:

```properties
# imports '/uttu/database/credentials' secrets (JSON blob) as structured
# properties into current configuration, with prefix key uttudb.
spring.config.import=aws-secretsmanager:/uttu/database/credentials?prefix=uttudb.

# wrap DataSource driver with AWS Secrets Manager aware driver...
spring.datasource.driver-class-name=com.amazonaws.secretsmanager.sql.AWSSecretsManagerPostgreSQLDriver

# ...which is then given a parameterized special JDBC connection URI...
spring.datasource.url=jdbc-secretsmanager:postgresql://${uttudb.host}:${uttudb.port}/${uttudb.dbname}?currentSchema=${uttudb.dbname}

# ...and Secrets Manager key name to look up database's secrets and other
# parameters without ever including direct values into the application configuration itself
spring.datasource.username=/uttu/database/credentials
```

Both of these libraries utilize AWS' automatic identity management based on where the code is running, meaning the runtime environment itself has automatically access to specific resources without need to carry e.g. secret key as part of the deployment, only the references to where such key would be found.

On more nifty thing is that this also allows for rotating credentials without redeployment, as `AWSSecretsManagerPostgreSQLDriver` will re-resolve the credentials on authentication errors.