### PR TITLE
document how to prevent faulty activation of s3 autoconfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,21 @@ The default MessagingService implementation is a noop.
 
 ## Disable Google PubSub autoconfiguration
 
-If you don't use Google PubSub, sett this property:
+If you don't use Google PubSub, set this property:
 
     # This property is needed to avoid pubsub autoconfiguration
     spring.cloud.gcp.pubsub.enabled=false
+
+## Disable AWS S3 autoconfiguration
+
+If you don't use AWS S3 through AWSpring, set this property:
+
+    # This property is needed to avoid AWS S3 autoconfiguration
+    spring.cloud.aws.s3.enabled=false
+
+This feature is automatically enabled due to transitive dependency activation from 
+`spring-cloud-aws-starter-secrets-manager` and should never be needed when running uttu in any of the available 
+configurations.
 
 ## Running locally
 


### PR DESCRIPTION
the [AWSpring](https://awspring.io/) project is a bit weird, the reason S3 autoconfiguration was enabled is because

 - `spring-cloud-aws-starter-secrets-manager` depends on `spring-cloud-aws-starter`
 - `spring-cloud-aws-starter` depends on `spring-cloud-aws-autoconfigure`
 - and in `spring-cloud-aws-autoconfigure` exists [S3AutoConfiguration.java](https://github.com/awspring/spring-cloud-aws/blob/main/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/s3/S3AutoConfiguration.java) with
    ```java
    @ConditionalOnClass({ S3Client.class, S3OutputStreamProvider.class })  // these are in classpath because we have manual S3 integration
    @ConditionalOnProperty(name = "spring.cloud.aws.s3.enabled", havingValue = "true", matchIfMissing = true)
    ```

This might be worth filing an issue to AWSpring if one doesn't already exist, although I wouldn't hold my breath on this getting fixed on their side.