### PR TITLE
Fix organisation exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,31 @@ or provide your own implementation of the [`OrganisationRegistry`](src/main/java
 Refer to [`src/test/resources/fixtures/organisations.xml`](src/test/resources/fixtures/organisations.xml) for an example 
 of a NeTEx file with organisations.
 
+### Override exported authority or operator id
+
+It is possible to override the exported authority or operator id for a given organisation like this:
+
+```properties
+no.entur.uttu.organisations.overrides={\
+    'SomeInternalId': {\
+        'Operator': 'KOL:Operator:BAR',\
+        'Authority': 'KOL:Authority:BAR'\
+    }\
+}
+```
+
+This is useful if the organisation registry uses internal IDs, but you need to map them to "NeTEx" IDs.
+
+You can also map an existing NeTEx ID to something else:
+
+```properties
+no.entur.uttu.organisations.overrides={\
+    'FOO:Operator:BAR': {\
+        'Operator': 'FOO:Operator:BAZ'\
+    }\
+}
+```
+
 ## Stop place registry
 
 Uttu needs a stop place registry in order to allow lookup of stop places from quay refs, used when creating

--- a/src/main/java/no/entur/uttu/export/netex/producer/common/OrganisationProducer.java
+++ b/src/main/java/no/entur/uttu/export/netex/producer/common/OrganisationProducer.java
@@ -16,7 +16,6 @@
 package no.entur.uttu.export.netex.producer.common;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/src/main/java/no/entur/uttu/export/netex/producer/common/OrganisationProducer.java
+++ b/src/main/java/no/entur/uttu/export/netex/producer/common/OrganisationProducer.java
@@ -169,7 +169,7 @@ public class OrganisationProducer {
     return getNetexId(organisation, "Authority");
   }
 
-  protected String getNetexId(Organisation organisation, String type) {
+  private String getNetexId(Organisation organisation, String type) {
     if (
       organisationsOverrides.containsKey(organisation.getId()) &&
       organisationsOverrides.get(organisation.getId()).containsKey(type)
@@ -177,7 +177,18 @@ public class OrganisationProducer {
       return organisationsOverrides.get(organisation.getId()).get(type);
     }
 
-    Optional<String> fromKeyValue = Optional
+    String legacyId = extractLegacyId(organisation, type);
+    if (legacyId != null) return legacyId;
+
+    if (convertOrgId) {
+      return organisation.getId().replace("Organisation", type);
+    }
+
+    return organisation.getId();
+  }
+
+  protected static String extractLegacyId(Organisation organisation, String type) {
+    return Optional
       .ofNullable(organisation.getKeyList())
       .flatMap(kl ->
         kl
@@ -190,16 +201,7 @@ public class OrganisationProducer {
           .flatMap(value ->
             Arrays.stream(value).filter(id -> id.contains(type)).findFirst()
           )
-      );
-
-    if (fromKeyValue.isPresent()) {
-      return fromKeyValue.get();
-    }
-
-    if (convertOrgId) {
-      return organisation.getId().replace("Organisation", type);
-    }
-
-    return organisation.getId();
+      )
+      .orElse(null);
   }
 }

--- a/src/main/java/no/entur/uttu/export/netex/producer/common/OrganisationProducer.java
+++ b/src/main/java/no/entur/uttu/export/netex/producer/common/OrganisationProducer.java
@@ -25,10 +25,10 @@ import no.entur.uttu.model.job.SeverityEnumeration;
 import no.entur.uttu.organisation.spi.OrganisationRegistry;
 import org.rutebanken.netex.model.Authority;
 import org.rutebanken.netex.model.AuthorityRef;
-import org.rutebanken.netex.model.GeneralOrganisation;
 import org.rutebanken.netex.model.KeyValueStructure;
 import org.rutebanken.netex.model.Operator;
 import org.rutebanken.netex.model.OperatorRefStructure;
+import org.rutebanken.netex.model.Organisation;
 import org.rutebanken.netex.model.Organisation_VersionStructure;
 import org.springframework.stereotype.Component;
 
@@ -85,7 +85,7 @@ public class OrganisationProducer {
   }
 
   private Authority mapAuthority(String authorityRef, NetexExportContext context) {
-    Optional<GeneralOrganisation> orgRegAuthority = organisationRegistry.getOrganisation(
+    Optional<Organisation> orgRegAuthority = organisationRegistry.getOrganisation(
       authorityRef
     );
     if (orgRegAuthority.isEmpty()) {
@@ -97,7 +97,7 @@ public class OrganisationProducer {
       return new Authority();
     }
 
-    GeneralOrganisation organisation = orgRegAuthority.get();
+    Organisation organisation = orgRegAuthority.get();
 
     if (
       organisation.getContactDetails() == null ||
@@ -119,7 +119,7 @@ public class OrganisationProducer {
   }
 
   private Operator mapOperator(String operatorRef, NetexExportContext context) {
-    Optional<GeneralOrganisation> orgRegOperator = organisationRegistry.getOrganisation(
+    Optional<Organisation> orgRegOperator = organisationRegistry.getOrganisation(
       operatorRef
     );
 
@@ -132,7 +132,7 @@ public class OrganisationProducer {
       return new Operator();
     }
 
-    GeneralOrganisation organisation = orgRegOperator.get();
+    Organisation organisation = orgRegOperator.get();
 
     return populateNetexOrganisation(new Operator(), organisation)
       .withId(getOperatorNetexId(organisation))
@@ -141,7 +141,7 @@ public class OrganisationProducer {
 
   private <N extends Organisation_VersionStructure> N populateNetexOrganisation(
     N netexOrg,
-    GeneralOrganisation orgRegOrg
+    Organisation orgRegOrg
   ) {
     netexOrg
       .withVersion(orgRegOrg.getVersion())
@@ -152,15 +152,15 @@ public class OrganisationProducer {
     return netexOrg;
   }
 
-  private String getOperatorNetexId(GeneralOrganisation organisation) {
+  private String getOperatorNetexId(Organisation organisation) {
     return getNetexId(organisation, "Operator");
   }
 
-  private String getAuthorityNetexId(GeneralOrganisation organisation) {
+  private String getAuthorityNetexId(Organisation organisation) {
     return getNetexId(organisation, "Authority");
   }
 
-  protected static String getNetexId(GeneralOrganisation organisation, String type) {
+  protected static String getNetexId(Organisation organisation, String type) {
     return Optional
       .ofNullable(organisation.getKeyList())
       .flatMap(kl ->

--- a/src/main/java/no/entur/uttu/export/netex/producer/common/OrganisationProducer.java
+++ b/src/main/java/no/entur/uttu/export/netex/producer/common/OrganisationProducer.java
@@ -155,16 +155,12 @@ public class OrganisationProducer {
       return organisationsOverrides.get(organisation.getId()).get(type);
     }
 
-    String legacyId = extractLegacyId(organisation, type);
-    if (legacyId != null) return legacyId;
-
-    return organisation.getId();
+    return extractLegacyId(organisation, type).orElse(organisation.getId());
   }
 
-  protected static <T extends Organisation_VersionStructure> String extractLegacyId(
-    T organisation,
-    String type
-  ) {
+  protected static <
+    T extends Organisation_VersionStructure
+  > Optional<String> extractLegacyId(T organisation, String type) {
     return Optional
       .ofNullable(organisation.getKeyList())
       .flatMap(kl ->
@@ -178,7 +174,6 @@ public class OrganisationProducer {
           .flatMap(value ->
             Arrays.stream(value).filter(id -> id.contains(type)).findFirst()
           )
-      )
-      .orElse(null);
+      );
   }
 }

--- a/src/main/java/no/entur/uttu/export/netex/producer/common/OrganisationProducer.java
+++ b/src/main/java/no/entur/uttu/export/netex/producer/common/OrganisationProducer.java
@@ -38,8 +38,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class OrganisationProducer {
 
-  @Value("#{${no.entur.uttu.organisations.overrides}}")
-  private Map<String, Map<String, String>> organisationsOverrides = new HashMap<>();
+  @Value(
+    "#{${no.entur.uttu.organisations.overrides:{T(java.util.Collections).emptyMap()}}}"
+  )
+  private Map<String, Map<String, String>> organisationsOverrides;
 
   @Value("${no.entur.uttu.organisations.convert-org-id:false}")
   private boolean convertOrgId;

--- a/src/main/java/no/entur/uttu/export/netex/producer/common/OrganisationProducer.java
+++ b/src/main/java/no/entur/uttu/export/netex/producer/common/OrganisationProducer.java
@@ -170,7 +170,10 @@ public class OrganisationProducer {
   }
 
   protected String getNetexId(Organisation organisation, String type) {
-    if (organisationsOverrides.containsKey(organisation.getId()) && organisationsOverrides.get(organisation.getId()).containsKey(type)) {
+    if (
+      organisationsOverrides.containsKey(organisation.getId()) &&
+      organisationsOverrides.get(organisation.getId()).containsKey(type)
+    ) {
       return organisationsOverrides.get(organisation.getId()).get(type);
     }
 
@@ -189,14 +192,14 @@ public class OrganisationProducer {
           )
       );
 
-      if (fromKeyValue.isPresent()) {
-        return fromKeyValue.get();
-      }
+    if (fromKeyValue.isPresent()) {
+      return fromKeyValue.get();
+    }
 
-      if (convertOrgId) {
-        return organisation.getId().replace("Organisation", type);
-      }
+    if (convertOrgId) {
+      return organisation.getId().replace("Organisation", type);
+    }
 
-      return organisation.getId();
+    return organisation.getId();
   }
 }

--- a/src/main/java/no/entur/uttu/graphql/LinesGraphQLSchema.java
+++ b/src/main/java/no/entur/uttu/graphql/LinesGraphQLSchema.java
@@ -86,6 +86,7 @@ import no.entur.uttu.repository.NetworkRepository;
 import org.locationtech.jts.geom.Geometry;
 import org.rutebanken.netex.model.AllVehicleModesOfTransportEnumeration;
 import org.rutebanken.netex.model.GeneralOrganisation;
+import org.rutebanken.netex.model.Organisation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -151,7 +152,7 @@ public class LinesGraphQLSchema {
   private DayTypeRepository dayTypeRepository;
 
   @Autowired
-  private DataFetcher<List<GeneralOrganisation>> organisationsFetcher;
+  private DataFetcher<List<Organisation>> organisationsFetcher;
 
   @Autowired
   private DataFetcher<TimetabledPassingTime.StopPlace> quayRefSearchFetcher;

--- a/src/main/java/no/entur/uttu/graphql/LinesGraphQLSchema.java
+++ b/src/main/java/no/entur/uttu/graphql/LinesGraphQLSchema.java
@@ -49,6 +49,7 @@ import no.entur.uttu.config.Context;
 import no.entur.uttu.export.linestatistics.ExportedLineStatisticsService;
 import no.entur.uttu.graphql.fetchers.DayTypeServiceJourneyCountFetcher;
 import no.entur.uttu.graphql.fetchers.ExportedPublicLinesFetcher;
+import no.entur.uttu.graphql.model.Organisation;
 import no.entur.uttu.graphql.model.StopPlace;
 import no.entur.uttu.graphql.scalars.DateScalar;
 import no.entur.uttu.graphql.scalars.DateTimeScalar;
@@ -85,7 +86,8 @@ import no.entur.uttu.repository.FlexibleStopPlaceRepository;
 import no.entur.uttu.repository.NetworkRepository;
 import org.locationtech.jts.geom.Geometry;
 import org.rutebanken.netex.model.AllVehicleModesOfTransportEnumeration;
-import org.rutebanken.netex.model.Organisation;
+import org.rutebanken.netex.model.OrganisationTypeEnumeration;
+import org.rutebanken.netex.model.Organisation_VersionStructure;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -243,6 +245,12 @@ public class LinesGraphQLSchema {
     (AllVehicleModesOfTransportEnumeration::value)
   );
 
+  private GraphQLEnumType organisationTypeEnum = createEnum(
+    "OrganisationType",
+    OrganisationTypeEnumeration.values(),
+    (OrganisationTypeEnumeration::value)
+  );
+
   private GraphQLObjectType lineObjectType;
   private GraphQLObjectType fixedLineObjectType;
   private GraphQLObjectType flexibleLineObjectType;
@@ -356,19 +364,6 @@ public class LinesGraphQLSchema {
       .name("KeyValues")
       .field(newFieldDefinition().name(FIELD_KEY).type(GraphQLString))
       .field(newFieldDefinition().name(FIELD_VALUES).type(new GraphQLList(GraphQLString)))
-      .build();
-
-    GraphQLObjectType keyValueObjectType = newObject()
-      .name("KeyValue")
-      .field(newFieldDefinition().name(FIELD_KEY).type(GraphQLString))
-      .field(newFieldDefinition().name("value").type(GraphQLString))
-      .build();
-
-    GraphQLObjectType keyListObjectType = newObject()
-      .name("KeyList")
-      .field(
-        newFieldDefinition().name("keyValue").type(new GraphQLList(keyValueObjectType))
-      )
       .build();
 
     GraphQLObjectType identifiedEntityObjectType = newObject()
@@ -917,8 +912,7 @@ public class LinesGraphQLSchema {
         .field(versionField)
         .field(newFieldDefinition().name(FIELD_NAME).type(multilingualStringObjectType))
         .field(newFieldDefinition().name("legalName").type(multilingualStringObjectType))
-        .field(newFieldDefinition().name("contactDetails").type(contactObjectType))
-        .field(newFieldDefinition().name("keyList").type(keyListObjectType))
+        .field(newFieldDefinition().name("type").type(organisationTypeEnum))
         .build();
   }
 

--- a/src/main/java/no/entur/uttu/graphql/LinesGraphQLSchema.java
+++ b/src/main/java/no/entur/uttu/graphql/LinesGraphQLSchema.java
@@ -911,7 +911,6 @@ public class LinesGraphQLSchema {
         .field(newFieldDefinition().name(FIELD_ID).type(GraphQLID))
         .field(versionField)
         .field(newFieldDefinition().name(FIELD_NAME).type(multilingualStringObjectType))
-        .field(newFieldDefinition().name("legalName").type(multilingualStringObjectType))
         .field(newFieldDefinition().name("type").type(organisationTypeEnum))
         .build();
   }

--- a/src/main/java/no/entur/uttu/graphql/LinesGraphQLSchema.java
+++ b/src/main/java/no/entur/uttu/graphql/LinesGraphQLSchema.java
@@ -85,7 +85,6 @@ import no.entur.uttu.repository.FlexibleStopPlaceRepository;
 import no.entur.uttu.repository.NetworkRepository;
 import org.locationtech.jts.geom.Geometry;
 import org.rutebanken.netex.model.AllVehicleModesOfTransportEnumeration;
-import org.rutebanken.netex.model.GeneralOrganisation;
 import org.rutebanken.netex.model.Organisation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;

--- a/src/main/java/no/entur/uttu/graphql/fetchers/OrganisationsFetcher.java
+++ b/src/main/java/no/entur/uttu/graphql/fetchers/OrganisationsFetcher.java
@@ -2,9 +2,11 @@ package no.entur.uttu.graphql.fetchers;
 
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import java.util.ArrayList;
 import java.util.List;
+import no.entur.uttu.graphql.model.Organisation;
 import no.entur.uttu.organisation.spi.OrganisationRegistry;
-import org.rutebanken.netex.model.Organisation;
+import org.rutebanken.netex.model.OrganisationTypeEnumeration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -16,6 +18,33 @@ public class OrganisationsFetcher implements DataFetcher<List<Organisation>> {
 
   @Override
   public List<Organisation> get(DataFetchingEnvironment environment) throws Exception {
-    return organisationRegistry.getOrganisations();
+    List<Organisation> organisations = new ArrayList<>();
+
+    organisationRegistry
+      .getAuthorities()
+      .forEach(authority ->
+        organisations.add(
+          new Organisation(
+            authority.getId(),
+            authority.getName(),
+            authority.getLegalName(),
+            OrganisationTypeEnumeration.AUTHORITY
+          )
+        )
+      );
+
+    organisationRegistry
+      .getOperators()
+      .forEach(operator ->
+        organisations.add(
+          new Organisation(
+            operator.getId(),
+            operator.getName(),
+            operator.getLegalName(),
+            OrganisationTypeEnumeration.OPERATOR
+          )
+        )
+      );
+    return organisations;
   }
 }

--- a/src/main/java/no/entur/uttu/graphql/fetchers/OrganisationsFetcher.java
+++ b/src/main/java/no/entur/uttu/graphql/fetchers/OrganisationsFetcher.java
@@ -4,19 +4,18 @@ import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.List;
 import no.entur.uttu.organisation.spi.OrganisationRegistry;
-import org.rutebanken.netex.model.GeneralOrganisation;
+import org.rutebanken.netex.model.Organisation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service("organisationsFetcher")
-public class OrganisationsFetcher implements DataFetcher<List<GeneralOrganisation>> {
+public class OrganisationsFetcher implements DataFetcher<List<Organisation>> {
 
   @Autowired
   OrganisationRegistry organisationRegistry;
 
   @Override
-  public List<GeneralOrganisation> get(DataFetchingEnvironment environment)
-    throws Exception {
+  public List<Organisation> get(DataFetchingEnvironment environment) throws Exception {
     return organisationRegistry.getOrganisations();
   }
 }

--- a/src/main/java/no/entur/uttu/graphql/fetchers/OrganisationsFetcher.java
+++ b/src/main/java/no/entur/uttu/graphql/fetchers/OrganisationsFetcher.java
@@ -27,7 +27,6 @@ public class OrganisationsFetcher implements DataFetcher<List<Organisation>> {
           new Organisation(
             authority.getId(),
             authority.getName(),
-            authority.getLegalName(),
             OrganisationTypeEnumeration.AUTHORITY
           )
         )
@@ -40,7 +39,6 @@ public class OrganisationsFetcher implements DataFetcher<List<Organisation>> {
           new Organisation(
             operator.getId(),
             operator.getName(),
-            operator.getLegalName(),
             OrganisationTypeEnumeration.OPERATOR
           )
         )

--- a/src/main/java/no/entur/uttu/graphql/model/Organisation.java
+++ b/src/main/java/no/entur/uttu/graphql/model/Organisation.java
@@ -1,0 +1,11 @@
+package no.entur.uttu.graphql.model;
+
+import org.rutebanken.netex.model.MultilingualString;
+import org.rutebanken.netex.model.OrganisationTypeEnumeration;
+
+public record Organisation(
+  String id,
+  MultilingualString name,
+  MultilingualString legalName,
+  OrganisationTypeEnumeration type
+) {}

--- a/src/main/java/no/entur/uttu/graphql/model/Organisation.java
+++ b/src/main/java/no/entur/uttu/graphql/model/Organisation.java
@@ -6,6 +6,5 @@ import org.rutebanken.netex.model.OrganisationTypeEnumeration;
 public record Organisation(
   String id,
   MultilingualString name,
-  MultilingualString legalName,
   OrganisationTypeEnumeration type
 ) {}

--- a/src/main/java/no/entur/uttu/organisation/NetexPublicationDeliveryFileOrganisationRegistry.java
+++ b/src/main/java/no/entur/uttu/organisation/NetexPublicationDeliveryFileOrganisationRegistry.java
@@ -11,7 +11,7 @@ import no.entur.uttu.netex.NetexUnmarshaller;
 import no.entur.uttu.netex.NetexUnmarshallerUnmarshalFromSourceException;
 import no.entur.uttu.organisation.spi.OrganisationRegistry;
 import no.entur.uttu.util.Preconditions;
-import org.rutebanken.netex.model.GeneralOrganisation;
+import org.rutebanken.netex.model.Organisation;
 import org.rutebanken.netex.model.PublicationDeliveryStructure;
 import org.rutebanken.netex.model.ResourceFrame;
 import org.slf4j.Logger;
@@ -36,7 +36,7 @@ public class NetexPublicationDeliveryFileOrganisationRegistry
     PublicationDeliveryStructure.class
   );
 
-  private List<GeneralOrganisation> organisations = List.of();
+  private List<Organisation> organisations = List.of();
 
   @Value("${uttu.organisations.netex-file-uri}")
   String netexFileUri;
@@ -57,24 +57,25 @@ public class NetexPublicationDeliveryFileOrganisationRegistry
                 .getOrganisations()
                 .getOrganisation_()
                 .stream()
-                .map(org -> (GeneralOrganisation) org.getValue())
+                .map(org -> (Organisation) org.getValue())
                 .toList();
           }
         });
     } catch (NetexUnmarshallerUnmarshalFromSourceException e) {
       logger.warn(
-        "Unable to unmarshal organisations xml, organisation registry will be an empty list"
+        "Unable to unmarshal organisations xml, organisation registry will be an empty list",
+        e
       );
     }
   }
 
   @Override
-  public List<GeneralOrganisation> getOrganisations() {
+  public List<Organisation> getOrganisations() {
     return organisations;
   }
 
   @Override
-  public Optional<GeneralOrganisation> getOrganisation(String id) {
+  public Optional<Organisation> getOrganisation(String id) {
     return organisations.stream().filter(org -> org.getId().equals(id)).findFirst();
   }
 

--- a/src/main/java/no/entur/uttu/organisation/spi/OrganisationRegistry.java
+++ b/src/main/java/no/entur/uttu/organisation/spi/OrganisationRegistry.java
@@ -3,7 +3,7 @@ package no.entur.uttu.organisation.spi;
 import java.util.List;
 import java.util.Optional;
 import no.entur.uttu.error.codedexception.CodedIllegalArgumentException;
-import org.rutebanken.netex.model.GeneralOrganisation;
+import org.rutebanken.netex.model.Organisation;
 
 /**
  * Represents an organisation registry used to populate authorities and operators references
@@ -12,12 +12,12 @@ public interface OrganisationRegistry {
   /**
    * Get a list of all organisations in the registry
    */
-  List<GeneralOrganisation> getOrganisations();
+  List<Organisation> getOrganisations();
 
   /**
    * Get an organisation with the given ID, which may not exist
    */
-  Optional<GeneralOrganisation> getOrganisation(String id);
+  Optional<Organisation> getOrganisation(String id);
 
   /**
    * Check if the organisation represented by the operator reference id is a valid operator

--- a/src/main/java/no/entur/uttu/organisation/spi/OrganisationRegistry.java
+++ b/src/main/java/no/entur/uttu/organisation/spi/OrganisationRegistry.java
@@ -3,21 +3,32 @@ package no.entur.uttu.organisation.spi;
 import java.util.List;
 import java.util.Optional;
 import no.entur.uttu.error.codedexception.CodedIllegalArgumentException;
-import org.rutebanken.netex.model.Organisation;
+import org.rutebanken.netex.model.Authority;
+import org.rutebanken.netex.model.Operator;
 
 /**
  * Represents an organisation registry used to populate authorities and operators references
  */
 public interface OrganisationRegistry {
   /**
-   * Get a list of all organisations in the registry
+   * Get a list of all authorities in the registry
    */
-  List<Organisation> getOrganisations();
+  List<Authority> getAuthorities();
 
   /**
-   * Get an organisation with the given ID, which may not exist
+   * Get an authority with the given ID, which may not exist
    */
-  Optional<Organisation> getOrganisation(String id);
+  Optional<Authority> getAuthority(String id);
+
+  /**
+   * Get a list of all operators in the registry
+   */
+  List<Operator> getOperators();
+
+  /**
+   * Get an operator with the given ID, which may not exist
+   */
+  Optional<Operator> getOperator(String id);
 
   /**
    * Check if the organisation represented by the operator reference id is a valid operator

--- a/src/test/groovy/no/entur/uttu/graphql/AbstractFixedLinesGraphQLIntegrationTest.groovy
+++ b/src/test/groovy/no/entur/uttu/graphql/AbstractFixedLinesGraphQLIntegrationTest.groovy
@@ -111,7 +111,7 @@ abstract class AbstractFixedLinesGraphQLIntegrationTest extends AbstractGraphQLR
                 "transportMode": "bus",
                 "transportSubmode": "localBus",
                 "networkRef": "$networkId",
-                "operatorRef": "NOG:GeneralOrganisation:1",
+                "operatorRef": "NOG:Organisation:1",
                 "notices": [{"text": "Dette er en fiktiv linje."}],
                 "journeyPatterns": [
                   {

--- a/src/test/groovy/no/entur/uttu/graphql/AbstractFixedLinesGraphQLIntegrationTest.groovy
+++ b/src/test/groovy/no/entur/uttu/graphql/AbstractFixedLinesGraphQLIntegrationTest.groovy
@@ -111,7 +111,7 @@ abstract class AbstractFixedLinesGraphQLIntegrationTest extends AbstractGraphQLR
                 "transportMode": "bus",
                 "transportSubmode": "localBus",
                 "networkRef": "$networkId",
-                "operatorRef": "NOG:Organisation:1",
+                "operatorRef": "NOG:Operator:1",
                 "notices": [{"text": "Dette er en fiktiv linje."}],
                 "journeyPatterns": [
                   {

--- a/src/test/groovy/no/entur/uttu/graphql/AbstractFlexibleLinesGraphQLIntegrationTest.groovy
+++ b/src/test/groovy/no/entur/uttu/graphql/AbstractFlexibleLinesGraphQLIntegrationTest.groovy
@@ -199,7 +199,7 @@ abstract class AbstractFlexibleLinesGraphQLIntegrationTest extends AbstractGraph
     }
 
     ValidatableResponse createFlexibleLine(String name) {
-        return createFlexibleLine(name, 'NOG:Organisation:1')
+        return createFlexibleLine(name, 'NOG:Operator:1')
     }
 
 

--- a/src/test/groovy/no/entur/uttu/graphql/AbstractFlexibleLinesGraphQLIntegrationTest.groovy
+++ b/src/test/groovy/no/entur/uttu/graphql/AbstractFlexibleLinesGraphQLIntegrationTest.groovy
@@ -199,7 +199,7 @@ abstract class AbstractFlexibleLinesGraphQLIntegrationTest extends AbstractGraph
     }
 
     ValidatableResponse createFlexibleLine(String name) {
-        return createFlexibleLine(name, 'NOG:GeneralOrganisation:1')
+        return createFlexibleLine(name, 'NOG:Organisation:1')
     }
 
 

--- a/src/test/groovy/no/entur/uttu/graphql/AbstractGraphQLResourceIntegrationTest.groovy
+++ b/src/test/groovy/no/entur/uttu/graphql/AbstractGraphQLResourceIntegrationTest.groovy
@@ -62,7 +62,7 @@ abstract class AbstractGraphQLResourceIntegrationTest extends UttuIntegrationTes
         String variables = """{
             "network": {
                 "name": "$name",
-                "authorityRef": "NOG:GeneralOrganisation:1"
+                "authorityRef": "NOG:Organisation:1"
             }
         }"""
 

--- a/src/test/groovy/no/entur/uttu/graphql/AbstractGraphQLResourceIntegrationTest.groovy
+++ b/src/test/groovy/no/entur/uttu/graphql/AbstractGraphQLResourceIntegrationTest.groovy
@@ -62,7 +62,7 @@ abstract class AbstractGraphQLResourceIntegrationTest extends UttuIntegrationTes
         String variables = """{
             "network": {
                 "name": "$name",
-                "authorityRef": "NOG:Organisation:1"
+                "authorityRef": "NOG:Authority:1"
             }
         }"""
 

--- a/src/test/groovy/no/entur/uttu/graphql/FlexibleLineGraphQLIntegrationTest.groovy
+++ b/src/test/groovy/no/entur/uttu/graphql/FlexibleLineGraphQLIntegrationTest.groovy
@@ -36,7 +36,7 @@ class FlexibleLineGraphQLIntegrationTest extends AbstractFlexibleLinesGraphQLInt
 
     @Test
     void createFlexibleLineWithInvalidOperator() {
-        createFlexibleLine(testFlexibleLineWithInvalidOperatorName, 'NOG:GeneralOrganisation:2')
+        createFlexibleLine(testFlexibleLineWithInvalidOperatorName, 'NOG:Organisation:2')
             .body("errors[0].extensions.code", equalTo("ORGANISATION_NOT_IN_ORGANISATION_REGISTRY"))
     }
 

--- a/src/test/groovy/no/entur/uttu/graphql/FlexibleLineGraphQLIntegrationTest.groovy
+++ b/src/test/groovy/no/entur/uttu/graphql/FlexibleLineGraphQLIntegrationTest.groovy
@@ -43,7 +43,7 @@ class FlexibleLineGraphQLIntegrationTest extends AbstractFlexibleLinesGraphQLInt
     @Test
     void createFlexibleLineWithExistingName() {
         String name = "foobar"
-        String operatorRef = "NOG:GeneralOrganisation:1"
+        String operatorRef = "NOG:Organisation:1"
         String networkId = getNetworkId(createNetwork(name))
         String flexAreaStopPlaceId = getFlexibleStopPlaceId(createFlexibleStopPlaceWithFlexibleArea(name + "FlexArea"))
         String hailAndRideStopPlaceId = getFlexibleStopPlaceId(createFlexibleStopPlaceWithHailAndRideArea(name + "HailAndRide"))

--- a/src/test/groovy/no/entur/uttu/graphql/FlexibleLineGraphQLIntegrationTest.groovy
+++ b/src/test/groovy/no/entur/uttu/graphql/FlexibleLineGraphQLIntegrationTest.groovy
@@ -36,14 +36,14 @@ class FlexibleLineGraphQLIntegrationTest extends AbstractFlexibleLinesGraphQLInt
 
     @Test
     void createFlexibleLineWithInvalidOperator() {
-        createFlexibleLine(testFlexibleLineWithInvalidOperatorName, 'NOG:Organisation:2')
+        createFlexibleLine(testFlexibleLineWithInvalidOperatorName, 'NOG:Operator:2')
             .body("errors[0].extensions.code", equalTo("ORGANISATION_NOT_IN_ORGANISATION_REGISTRY"))
     }
 
     @Test
     void createFlexibleLineWithExistingName() {
         String name = "foobar"
-        String operatorRef = "NOG:Organisation:1"
+        String operatorRef = "NOG:Operator:1"
         String networkId = getNetworkId(createNetwork(name))
         String flexAreaStopPlaceId = getFlexibleStopPlaceId(createFlexibleStopPlaceWithFlexibleArea(name + "FlexArea"))
         String hailAndRideStopPlaceId = getFlexibleStopPlaceId(createFlexibleStopPlaceWithHailAndRideArea(name + "HailAndRide"))

--- a/src/test/groovy/no/entur/uttu/graphql/NetworkGraphQLIntegrationTest.groovy
+++ b/src/test/groovy/no/entur/uttu/graphql/NetworkGraphQLIntegrationTest.groovy
@@ -39,6 +39,6 @@ class NetworkGraphQLIntegrationTest extends AbstractFlexibleLinesGraphQLIntegrat
     void assertNetworkResponse(ValidatableResponse rsp, String path) {
         rsp.body("data. "+path+".id", startsWith("TST:Network"))
                 .body("data. "+path+".name", equalTo(testNetworkName))
-                .body("data. "+path+".authorityRef", equalTo("NOG:GeneralOrganisation:1"))
+                .body("data. "+path+".authorityRef", equalTo("NOG:Organisation:1"))
     }
 }

--- a/src/test/groovy/no/entur/uttu/graphql/NetworkGraphQLIntegrationTest.groovy
+++ b/src/test/groovy/no/entur/uttu/graphql/NetworkGraphQLIntegrationTest.groovy
@@ -39,6 +39,6 @@ class NetworkGraphQLIntegrationTest extends AbstractFlexibleLinesGraphQLIntegrat
     void assertNetworkResponse(ValidatableResponse rsp, String path) {
         rsp.body("data. "+path+".id", startsWith("TST:Network"))
                 .body("data. "+path+".name", equalTo(testNetworkName))
-                .body("data. "+path+".authorityRef", equalTo("NOG:Organisation:1"))
+                .body("data. "+path+".authorityRef", equalTo("NOG:Authority:1"))
     }
 }

--- a/src/test/java/no/entur/uttu/export/netex/producer/common/OrganisationProducerTest.java
+++ b/src/test/java/no/entur/uttu/export/netex/producer/common/OrganisationProducerTest.java
@@ -13,57 +13,62 @@ public class OrganisationProducerTest {
   public void testExtractLegacyId() {
     Assertions.assertEquals(
       "TST:Operator:2",
-      OrganisationProducer.extractLegacyId(
-        new Operator()
-          .withId("notThis")
-          .withKeyList(
-            new KeyListStructure()
-              .withKeyValue(
-                new KeyValueStructure()
-                  .withKey("LegacyId")
-                  .withValue("TST:Authority:1,TST:Operator:2")
-              )
-          ),
-        "Operator"
-      ).get()
+      OrganisationProducer
+        .extractLegacyId(
+          new Operator()
+            .withId("notThis")
+            .withKeyList(
+              new KeyListStructure()
+                .withKeyValue(
+                  new KeyValueStructure()
+                    .withKey("LegacyId")
+                    .withValue("TST:Authority:1,TST:Operator:2")
+                )
+            ),
+          "Operator"
+        )
+        .get()
     );
 
     Assertions.assertEquals(
       "TST:Authority:1",
-      OrganisationProducer.extractLegacyId(
-        new Authority()
-          .withId("notThis")
-          .withKeyList(
-            new KeyListStructure()
-              .withKeyValue(
-                new KeyValueStructure()
-                  .withKey("LegacyId")
-                  .withValue("TST:Authority:1,TST:Operator:2")
-              )
-          ),
-        "Authority"
-      ).get()
+      OrganisationProducer
+        .extractLegacyId(
+          new Authority()
+            .withId("notThis")
+            .withKeyList(
+              new KeyListStructure()
+                .withKeyValue(
+                  new KeyValueStructure()
+                    .withKey("LegacyId")
+                    .withValue("TST:Authority:1,TST:Operator:2")
+                )
+            ),
+          "Authority"
+        )
+        .get()
     );
 
     Assertions.assertFalse(
-      OrganisationProducer.extractLegacyId(
-        new Operator()
-          .withId("TST:Operator:2")
-          .withKeyList(
-            new KeyListStructure()
-              .withKeyValue(
-                new KeyValueStructure().withKey("LegacyId").withValue("TST:Authority:1")
-              )
-          ),
-        "Operator"
-      ).isPresent()
+      OrganisationProducer
+        .extractLegacyId(
+          new Operator()
+            .withId("TST:Operator:2")
+            .withKeyList(
+              new KeyListStructure()
+                .withKeyValue(
+                  new KeyValueStructure().withKey("LegacyId").withValue("TST:Authority:1")
+                )
+            ),
+          "Operator"
+        )
+        .isPresent()
     );
 
     Assertions.assertFalse(
-      OrganisationProducer.extractLegacyId(
-        new Operator().withId("TST:Operator:2"),
-        "Operator"
-      ).isPresent()
+      OrganisationProducer
+        .extractLegacyId(new Operator().withId("TST:Operator:2"), "Operator")
+        .isPresent()
     );
   }
 }

--- a/src/test/java/no/entur/uttu/export/netex/producer/common/OrganisationProducerTest.java
+++ b/src/test/java/no/entur/uttu/export/netex/producer/common/OrganisationProducerTest.java
@@ -25,7 +25,7 @@ public class OrganisationProducerTest {
               )
           ),
         "Operator"
-      )
+      ).get()
     );
 
     Assertions.assertEquals(
@@ -42,10 +42,10 @@ public class OrganisationProducerTest {
               )
           ),
         "Authority"
-      )
+      ).get()
     );
 
-    Assertions.assertNull(
+    Assertions.assertFalse(
       OrganisationProducer.extractLegacyId(
         new Operator()
           .withId("TST:Operator:2")
@@ -56,14 +56,14 @@ public class OrganisationProducerTest {
               )
           ),
         "Operator"
-      )
+      ).isPresent()
     );
 
-    Assertions.assertNull(
+    Assertions.assertFalse(
       OrganisationProducer.extractLegacyId(
         new Operator().withId("TST:Operator:2"),
         "Operator"
-      )
+      ).isPresent()
     );
   }
 }

--- a/src/test/java/no/entur/uttu/export/netex/producer/common/OrganisationProducerTest.java
+++ b/src/test/java/no/entur/uttu/export/netex/producer/common/OrganisationProducerTest.java
@@ -5,15 +5,16 @@ import org.junit.jupiter.api.Assertions;
 import org.rutebanken.netex.model.GeneralOrganisation;
 import org.rutebanken.netex.model.KeyListStructure;
 import org.rutebanken.netex.model.KeyValueStructure;
+import org.rutebanken.netex.model.Organisation;
 
 public class OrganisationProducerTest {
 
   @Test
-  public void testGetNetexId() {
+  public void testExtractLegacyId() {
     Assertions.assertEquals(
       "TST:Operator:2",
-      OrganisationProducer.getNetexId(
-        new GeneralOrganisation()
+      OrganisationProducer.extractLegacyId(
+        new Organisation()
           .withId("notThis")
           .withKeyList(
             new KeyListStructure()
@@ -29,8 +30,8 @@ public class OrganisationProducerTest {
 
     Assertions.assertEquals(
       "TST:Authority:1",
-      OrganisationProducer.getNetexId(
-        new GeneralOrganisation()
+      OrganisationProducer.extractLegacyId(
+        new Organisation()
           .withId("notThis")
           .withKeyList(
             new KeyListStructure()
@@ -44,10 +45,9 @@ public class OrganisationProducerTest {
       )
     );
 
-    Assertions.assertEquals(
-      "TST:Operator:2",
-      OrganisationProducer.getNetexId(
-        new GeneralOrganisation()
+    Assertions.assertNull(
+      OrganisationProducer.extractLegacyId(
+        new Organisation()
           .withId("TST:Operator:2")
           .withKeyList(
             new KeyListStructure()
@@ -59,10 +59,9 @@ public class OrganisationProducerTest {
       )
     );
 
-    Assertions.assertEquals(
-      "TST:Operator:2",
-      OrganisationProducer.getNetexId(
-        new GeneralOrganisation().withId("TST:Operator:2"),
+    Assertions.assertNull(
+      OrganisationProducer.extractLegacyId(
+        new Organisation().withId("TST:Operator:2"),
         "Operator"
       )
     );

--- a/src/test/java/no/entur/uttu/export/netex/producer/common/OrganisationProducerTest.java
+++ b/src/test/java/no/entur/uttu/export/netex/producer/common/OrganisationProducerTest.java
@@ -2,7 +2,6 @@ package no.entur.uttu.export.netex.producer.common;
 
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
-import org.rutebanken.netex.model.GeneralOrganisation;
 import org.rutebanken.netex.model.KeyListStructure;
 import org.rutebanken.netex.model.KeyValueStructure;
 import org.rutebanken.netex.model.Organisation;

--- a/src/test/java/no/entur/uttu/export/netex/producer/common/OrganisationProducerTest.java
+++ b/src/test/java/no/entur/uttu/export/netex/producer/common/OrganisationProducerTest.java
@@ -2,9 +2,10 @@ package no.entur.uttu.export.netex.producer.common;
 
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.rutebanken.netex.model.Authority;
 import org.rutebanken.netex.model.KeyListStructure;
 import org.rutebanken.netex.model.KeyValueStructure;
-import org.rutebanken.netex.model.Organisation;
+import org.rutebanken.netex.model.Operator;
 
 public class OrganisationProducerTest {
 
@@ -13,7 +14,7 @@ public class OrganisationProducerTest {
     Assertions.assertEquals(
       "TST:Operator:2",
       OrganisationProducer.extractLegacyId(
-        new Organisation()
+        new Operator()
           .withId("notThis")
           .withKeyList(
             new KeyListStructure()
@@ -30,7 +31,7 @@ public class OrganisationProducerTest {
     Assertions.assertEquals(
       "TST:Authority:1",
       OrganisationProducer.extractLegacyId(
-        new Organisation()
+        new Authority()
           .withId("notThis")
           .withKeyList(
             new KeyListStructure()
@@ -46,7 +47,7 @@ public class OrganisationProducerTest {
 
     Assertions.assertNull(
       OrganisationProducer.extractLegacyId(
-        new Organisation()
+        new Operator()
           .withId("TST:Operator:2")
           .withKeyList(
             new KeyListStructure()
@@ -60,7 +61,7 @@ public class OrganisationProducerTest {
 
     Assertions.assertNull(
       OrganisationProducer.extractLegacyId(
-        new Organisation().withId("TST:Operator:2"),
+        new Operator().withId("TST:Operator:2"),
         "Operator"
       )
     );

--- a/src/test/resources/fixtures/organisations.xml
+++ b/src/test/resources/fixtures/organisations.xml
@@ -24,7 +24,7 @@
                 </Authority>
                 <Operator created="2023-06-30T12:00:00" id="NOG:Operator:1" version="1">
                     <validityConditions>
-                        <AvailabilityCondition id="NOG:AvailabilityCondition:1" version="1">
+                        <AvailabilityCondition id="NOG:AvailabilityCondition:2" version="1">
                             <FromDate>2023-06-20T00:00:00</FromDate>
                         </AvailabilityCondition>
                     </validityConditions>

--- a/src/test/resources/fixtures/organisations.xml
+++ b/src/test/resources/fixtures/organisations.xml
@@ -5,7 +5,7 @@
     <dataObjects>
         <ResourceFrame id="NOG:ResourceFrame:1" version="1">
             <organisations>
-                <Organisation created="2023-06-30T12:00:00" id="NOG:GeneralOrganisation:1" version="1">
+                <Organisation created="2023-06-30T12:00:00" id="NOG:Organisation:1" version="1">
                     <validityConditions>
                         <AvailabilityCondition id="NOG:AvailabilityCondition:1" version="1">
                             <FromDate>2023-06-20T00:00:00</FromDate>

--- a/src/test/resources/fixtures/organisations.xml
+++ b/src/test/resources/fixtures/organisations.xml
@@ -5,7 +5,7 @@
     <dataObjects>
         <ResourceFrame id="NOG:ResourceFrame:1" version="1">
             <organisations>
-                <GeneralOrganisation created="2023-06-30T12:00:00" id="NOG:GeneralOrganisation:1" version="1">
+                <Organisation created="2023-06-30T12:00:00" id="NOG:GeneralOrganisation:1" version="1">
                     <validityConditions>
                         <AvailabilityCondition id="NOG:AvailabilityCondition:1" version="1">
                             <FromDate>2023-06-20T00:00:00</FromDate>
@@ -21,7 +21,7 @@
                         <Phone>+15551234545</Phone>
                         <Url>https://www.fake.com/</Url>
                     </ContactDetails>
-                </GeneralOrganisation>
+                </Organisation>
             </organisations>
         </ResourceFrame>
     </dataObjects>

--- a/src/test/resources/fixtures/organisations.xml
+++ b/src/test/resources/fixtures/organisations.xml
@@ -5,7 +5,7 @@
     <dataObjects>
         <ResourceFrame id="NOG:ResourceFrame:1" version="1">
             <organisations>
-                <Organisation created="2023-06-30T12:00:00" id="NOG:Organisation:1" version="1">
+                <Authority created="2023-06-30T12:00:00" id="NOG:Authority:1" version="1">
                     <validityConditions>
                         <AvailabilityCondition id="NOG:AvailabilityCondition:1" version="1">
                             <FromDate>2023-06-20T00:00:00</FromDate>
@@ -21,7 +21,24 @@
                         <Phone>+15551234545</Phone>
                         <Url>https://www.fake.com/</Url>
                     </ContactDetails>
-                </Organisation>
+                </Authority>
+                <Operator created="2023-06-30T12:00:00" id="NOG:Operator:1" version="1">
+                    <validityConditions>
+                        <AvailabilityCondition id="NOG:AvailabilityCondition:1" version="1">
+                            <FromDate>2023-06-20T00:00:00</FromDate>
+                        </AvailabilityCondition>
+                    </validityConditions>
+                    <PrivateCode>1</PrivateCode>
+                    <CompanyNumber>123456789</CompanyNumber>
+                    <Name lang="en">Fake Organisation</Name>
+                    <LegalName>Fake Organisation LLC</LegalName>
+                    <TradingName lang="en">This is really fake</TradingName>
+                    <ContactDetails>
+                        <Email/>
+                        <Phone>+15551234545</Phone>
+                        <Url>https://www.fake.com/</Url>
+                    </ContactDetails>
+                </Operator>
             </organisations>
         </ResourceFrame>
     </dataObjects>


### PR DESCRIPTION
Summary:

* Change model used for orgs from GeneralOrganisation to Authority and Operator
* Adds configurable overrides for exported authority and operator ids

Authority and operator IDs are exported according to the following logic:

* If a configured override exists for the organisation in question, use it;
* else if the organisation has a LegacyId with the appropriate type (Authority or Operator) use first occurence;
* else use the organisation id