### PR TITLE
TIS-862/include export metadata for blobs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <java.version>21</java.version>
         <entur.google.pubsub.emulator.download.skip>true</entur.google.pubsub.emulator.download.skip>
 
-        <entur.helpers.version>2.32</entur.helpers.version>
+        <entur.helpers.version>2.33</entur.helpers.version>
 
         <entur-google-pubsub-version>${entur.helpers.version}</entur-google-pubsub-version>
         <gcp-storage.version>${entur.helpers.version}</gcp-storage.version>

--- a/src/main/java/no/entur/uttu/export/ExportService.java
+++ b/src/main/java/no/entur/uttu/export/ExportService.java
@@ -15,6 +15,11 @@
 
 package no.entur.uttu.export;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import no.entur.uttu.error.codedexception.CodedIllegalArgumentException;
 import no.entur.uttu.export.linestatistics.ExportedLineStatisticsService;
 import no.entur.uttu.export.messaging.spi.MessagingService;
@@ -32,12 +37,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 @Component
 public class ExportService {

--- a/src/main/java/no/entur/uttu/export/ExportService.java
+++ b/src/main/java/no/entur/uttu/export/ExportService.java
@@ -15,9 +15,6 @@
 
 package no.entur.uttu.export;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.util.List;
 import no.entur.uttu.error.codedexception.CodedIllegalArgumentException;
 import no.entur.uttu.export.linestatistics.ExportedLineStatisticsService;
 import no.entur.uttu.export.messaging.spi.MessagingService;
@@ -29,14 +26,26 @@ import no.entur.uttu.model.job.ExportMessage;
 import no.entur.uttu.model.job.SeverityEnumeration;
 import no.entur.uttu.util.ExportUtil;
 import org.apache.commons.io.IOUtils;
+import org.rutebanken.helper.storage.model.BlobDescriptor;
 import org.rutebanken.helper.storage.repository.BlobStoreRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
 @Component
 public class ExportService {
+
+  /**
+   * Object metadata key prefix to categorize where the possibly attached metadata originates from.
+   */
+  public static final String EXPORT_METADATA_PREFIX = "no.entur.uttu.export.";
 
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
@@ -82,13 +91,20 @@ public class ExportService {
       byte[] bytes = IOUtils.toByteArray(dataSetStream);
       ByteArrayInputStream bis = new ByteArrayInputStream(bytes);
 
+      Map<String, String> metadata = Map.of(
+        EXPORT_METADATA_PREFIX + "name",
+        export.getName()
+      );
+
       if (!export.isDryRun() && !exportHasErrors(export)) {
         String exportedDataSetFilename = ExportUtil.createExportedDataSetFilename(
           export.getProvider(),
           exportedFilenameSuffix
         );
         String blobName = exportFolder + exportedDataSetFilename;
-        blobStoreRepository.uploadBlob(blobName, bis);
+        blobStoreRepository.uploadBlob(
+          new BlobDescriptor(blobName, bis, Optional.empty(), Optional.of(metadata))
+        );
         bis.reset();
         // notify Marduk that a new export is available
         messagingService.notifyExport(
@@ -101,7 +117,14 @@ public class ExportService {
           .forEach(export::addExportedLineStatistics);
       }
       export.setFileName(exportFolder + ExportUtil.createBackupDataSetFilename(export));
-      blobStoreRepository.uploadBlob(export.getFileName(), bis);
+      blobStoreRepository.uploadBlob(
+        new BlobDescriptor(
+          export.getFileName(),
+          bis,
+          Optional.empty(),
+          Optional.of(metadata)
+        )
+      );
     } catch (CodedIllegalArgumentException iae) {
       ExportMessage msg = new ExportMessage(SeverityEnumeration.ERROR, iae.getCode());
       export.addMessage(msg);

--- a/src/main/java/no/entur/uttu/export/blob/S3BlobStoreRepository.java
+++ b/src/main/java/no/entur/uttu/export/blob/S3BlobStoreRepository.java
@@ -1,13 +1,8 @@
 package no.entur.uttu.export.blob;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.function.Function;
 import org.rutebanken.helper.storage.BlobAlreadyExistsException;
 import org.rutebanken.helper.storage.BlobStoreException;
+import org.rutebanken.helper.storage.model.BlobDescriptor;
 import org.rutebanken.helper.storage.repository.BlobStoreRepository;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
@@ -17,6 +12,14 @@ import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
 
 /**
  * <a href="https://aws.amazon.com/s3/">AWS S3</a> backed implementation of {@link BlobStoreRepository}.
@@ -49,29 +52,42 @@ public class S3BlobStoreRepository implements BlobStoreRepository {
   }
 
   @Override
-  public long uploadBlob(String objectName, InputStream inputStream) {
-    return uploadBlob(objectName, inputStream, null);
-  }
-
-  @Override
-  public long uploadBlob(String objectName, InputStream inputStream, String contentType) {
+  public long uploadBlob(BlobDescriptor blobDescriptor) {
     RequestBody body = null;
     try {
-      body = RequestBody.fromBytes(inputStream.readAllBytes());
+      body = RequestBody.fromBytes(blobDescriptor.inputStream().readAllBytes());
     } catch (IOException e) {
       throw new BlobStoreException("Failed to read all bytes from given InputStream", e);
     }
 
     s3Client.putObject(
       r -> {
-        r.bucket(containerName).key(objectName);
-        if (contentType != null) {
-          r.contentType(contentType);
-        }
+        r.bucket(containerName).key(blobDescriptor.name());
+        blobDescriptor.contentType().ifPresent(r::contentType);
+        blobDescriptor.metadata().ifPresent(r::metadata);
       },
       body
     );
     return UNKNOWN_LATEST_VERSION;
+  }
+
+  @Override
+  public long uploadBlob(String objectName, InputStream inputStream) {
+    return uploadBlob(
+      new BlobDescriptor(objectName, inputStream, Optional.empty(), Optional.empty())
+    );
+  }
+
+  @Override
+  public long uploadBlob(String objectName, InputStream inputStream, String contentType) {
+    return uploadBlob(
+      new BlobDescriptor(
+        objectName,
+        inputStream,
+        Optional.of(contentType),
+        Optional.empty()
+      )
+    );
   }
 
   @Override
@@ -81,7 +97,9 @@ public class S3BlobStoreRepository implements BlobStoreRepository {
         "Blob '" + objectName + "' already exists in bucket '" + containerName + "'"
       );
     } else {
-      return uploadBlob(objectName, inputStream);
+      return uploadBlob(
+        new BlobDescriptor(objectName, inputStream, Optional.empty(), Optional.empty())
+      );
     }
   }
 

--- a/src/main/java/no/entur/uttu/export/blob/S3BlobStoreRepository.java
+++ b/src/main/java/no/entur/uttu/export/blob/S3BlobStoreRepository.java
@@ -1,5 +1,12 @@
 package no.entur.uttu.export.blob;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
 import org.rutebanken.helper.storage.BlobAlreadyExistsException;
 import org.rutebanken.helper.storage.BlobStoreException;
 import org.rutebanken.helper.storage.model.BlobDescriptor;
@@ -12,14 +19,6 @@ import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.function.Function;
 
 /**
  * <a href="https://aws.amazon.com/s3/">AWS S3</a> backed implementation of {@link BlobStoreRepository}.

--- a/src/test/java/no/entur/uttu/export/blob/S3BlobStoreRepositoryTest.java
+++ b/src/test/java/no/entur/uttu/export/blob/S3BlobStoreRepositoryTest.java
@@ -1,5 +1,9 @@
 package no.entur.uttu.export.blob;
 
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Optional;
 import no.entur.uttu.UttuIntegrationTest;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
@@ -21,11 +25,6 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
-
-import java.io.ByteArrayInputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.Map;
-import java.util.Optional;
 
 @Testcontainers
 @ActiveProfiles({ "s3-blobstore" })


### PR DESCRIPTION
Include export metadata to objects when exporting.

This PR updates `rutebanken-helpers` to `2.33` which added support for object metadata injection (https://github.com/entur/rutebanken-helpers/issues/301) and reworks `ExportService` so that it always provides the metadata for the backing `BlobStoreRepository`. Metadata keys are prefixed with `no.entur.uttu.export.` to allow the consuming end to easily identify where the information originates from. Also enhances `S3BlobStoreRepository` to fully utilize this new functionality.