### PR TITLE
add routing profile for local development to docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ See also [Disable AWS S3 Autoconfiguration](#disable-aws-s3-autoconfiguration), 
 ### `routing` profile
 
 Provides pre-made configuration for running (presumably) [OSRM Server](https://project-osrm.org/) to be used for 
-navigation routing features. **However** the image used is not the default, but instead named `osrm-routing` to allow 
+navigation routing features. **However**, the image used is not the default, but instead named `osrm-routing` to allow 
 the use of custom internal/external image with precalculated data. As this is very dependent on how the image is 
 created, we recommend that you use the provided `Dockerfile` below as base and adapt accordingly:
 

--- a/README.md
+++ b/README.md
@@ -284,9 +284,8 @@ COPY --from=build /data /data
 ENTRYPOINT osrm-routed --algorithm mld /data/norway-latest.osrm
 ```
 
-Save the above into `Dockerfile` and build the image with
+Save the above into `Dockerfile-osrm-routing` and build the image with
 ```shell
-docker build --platform linux/amd64 -t osrm-routing .
-```
+docker build --platform linux/amd64 -f Dockerfile-osrm-routing -t osrm-routing .
 
 See also [Running locally](#running-locally).

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ COMPOSE_PROFILES=aws,routing docker compose up
 
 ### Default profile (no activation key)
 
-Starts up PostGIS server with settings matchin the ones in [`application-local.properties`](./src/main/resources/application-local.properties).
+Starts up PostGIS server with settings matching the ones in [`application-local.properties`](./src/main/resources/application-local.properties).
 
 ### `aws` profile
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,16 @@ services:
     networks:
       - uttu
 
+  osrm-server:
+    container_name: "${COMPOSE_PROJECT_NAME}_osrm"
+    profiles: ["routing"]
+    image: osrm-routing  # see README.md for information on how to obtain this image
+    platform: linux/amd64
+    ports:
+      - 5000:5000
+    networks:
+      - uttu
+
 volumes:
   postgres-data:
 


### PR DESCRIPTION
This adds OSRM server routing to the compose environment with instructions on how to package the image so that it can be used locally. The example is provided for convenience, and isn't how we actually do this, but it does serve as a baseline.

As one more note, the OSRM server with Norway data packaged and processed with it is about 3GB. This, and considering different users have different data needs is the main motivation why instructions for building the image are provided as manual step instead of further configuration at this point - obtaining the image might be wildly different to anyone using the routing functionality, and as the image sizes can be _very_ large, it's better to just assume this problem has been solved in some other way in the user's organization/architecture.