### PR TITLE
Fix/export service links inverted coordinates

### DIFF
--- a/src/ext/java/no/entur/uttu/ext/entur/stopplace/EnturMummuStopPlaceRegistry.java
+++ b/src/ext/java/no/entur/uttu/ext/entur/stopplace/EnturMummuStopPlaceRegistry.java
@@ -18,6 +18,7 @@ package no.entur.uttu.ext.entur.stopplace;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import jakarta.xml.bind.JAXBElement;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Collections;
@@ -29,6 +30,7 @@ import javax.annotation.PostConstruct;
 import no.entur.uttu.stopplace.filter.StopPlaceFilter;
 import no.entur.uttu.stopplace.spi.StopPlaceRegistry;
 import org.rutebanken.netex.model.EntityInVersionStructure;
+import org.rutebanken.netex.model.Quay;
 import org.rutebanken.netex.model.StopPlace;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -124,6 +126,21 @@ public class EnturMummuStopPlaceRegistry implements StopPlaceRegistry {
       logger.warn("Failed to get stop place by quay ref ${}", quayRef);
       return Optional.empty();
     }
+  }
+
+  @Override
+  public Optional<Quay> getQuayById(String id) {
+    return getStopPlaceByQuayRef(id)
+      .flatMap(stopPlace ->
+        stopPlace
+          .getQuays()
+          .getQuayRefOrQuay()
+          .stream()
+          .map(JAXBElement::getValue)
+          .map(Quay.class::cast)
+          .filter(quay -> id.equals(quay.getId()))
+          .findFirst()
+      );
   }
 
   public boolean currentValidityFilter(EntityInVersionStructure entity) {

--- a/src/main/java/no/entur/uttu/export/netex/producer/common/ServiceLinkProducer.java
+++ b/src/main/java/no/entur/uttu/export/netex/producer/common/ServiceLinkProducer.java
@@ -3,7 +3,6 @@ package no.entur.uttu.export.netex.producer.common;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import net.opengis.gml._3.DirectPositionListType;
 import net.opengis.gml._3.LineStringType;
 import no.entur.uttu.export.netex.NetexExportContext;
@@ -18,7 +17,6 @@ import org.rutebanken.netex.model.Projections_RelStructure;
 import org.rutebanken.netex.model.Quay;
 import org.rutebanken.netex.model.ScheduledStopPointRefStructure;
 import org.rutebanken.netex.model.ServiceLink;
-import org.rutebanken.netex.model.StopPlace;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -115,28 +113,11 @@ public class ServiceLinkProducer {
       .toList();
   }
 
-  Quay getQuay(String quayRef) {
-    Optional<StopPlace> stopPlaceOptional = stopPlaceRegistry.getStopPlaceByQuayRef(
-      quayRef
-    );
-    if (stopPlaceOptional.isEmpty()) {
-      return null;
-    }
-    StopPlace stopPlaceFrom = stopPlaceOptional.get();
-    List<Quay> stopPlaceFromQuays = stopPlaceFrom
-      .getQuays()
-      .getQuayRefOrQuay()
-      .stream()
-      .map(jaxbElement -> (org.rutebanken.netex.model.Quay) jaxbElement.getValue())
-      .toList();
-    return stopPlaceFromQuays
-      .stream()
-      .filter(quay -> quay.getId().equals(quayRef))
-      .toList()
-      .get(0);
+  private Quay getQuay(String quayRef) {
+    return stopPlaceRegistry.getQuayById(quayRef).orElse(null);
   }
 
-  String getLineStringId(Ref serviceLinkRef) {
+  private String getLineStringId(Ref serviceLinkRef) {
     String serviceLinkSuffix = NetexIdProducer.getObjectIdSuffix(serviceLinkRef.id);
     return "LS_" + serviceLinkSuffix;
   }

--- a/src/main/java/no/entur/uttu/export/netex/producer/common/ServiceLinkProducer.java
+++ b/src/main/java/no/entur/uttu/export/netex/producer/common/ServiceLinkProducer.java
@@ -55,8 +55,8 @@ public class ServiceLinkProducer {
         routeGeometry
           .coordinates()
           .forEach(location -> {
-            posListCoordinates.add(location.get(0).doubleValue());
             posListCoordinates.add(location.get(1).doubleValue());
+            posListCoordinates.add(location.get(0).doubleValue());
           });
 
         DirectPositionListType posList = new DirectPositionListType()

--- a/src/main/java/no/entur/uttu/graphql/fetchers/RoutingFetcher.java
+++ b/src/main/java/no/entur/uttu/graphql/fetchers/RoutingFetcher.java
@@ -2,14 +2,11 @@ package no.entur.uttu.graphql.fetchers;
 
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
-import java.util.List;
-import java.util.Optional;
 import no.entur.uttu.graphql.model.ServiceLink;
 import no.entur.uttu.routing.RouteGeometry;
 import no.entur.uttu.routing.RoutingService;
 import no.entur.uttu.stopplace.spi.StopPlaceRegistry;
 import org.rutebanken.netex.model.Quay;
-import org.rutebanken.netex.model.StopPlace;
 import org.springframework.stereotype.Service;
 
 @Service("routingFetcher")
@@ -52,27 +49,7 @@ public class RoutingFetcher implements DataFetcher<ServiceLink> {
     );
   }
 
-  Quay getQuay(String quayRef) {
-    if (quayRef == null) {
-      return null;
-    }
-    Optional<StopPlace> stopPlaceOptional = stopPlaceRegistry.getStopPlaceByQuayRef(
-      quayRef
-    );
-    if (stopPlaceOptional.isEmpty()) {
-      return null;
-    }
-    StopPlace stopPlaceFrom = stopPlaceOptional.get();
-    List<Quay> stopPlaceFromQuays = stopPlaceFrom
-      .getQuays()
-      .getQuayRefOrQuay()
-      .stream()
-      .map(jaxbElement -> (org.rutebanken.netex.model.Quay) jaxbElement.getValue())
-      .toList();
-    return stopPlaceFromQuays
-      .stream()
-      .filter(quay -> quay.getId().equals(quayRef))
-      .toList()
-      .get(0);
+  private Quay getQuay(String quayRef) {
+    return stopPlaceRegistry.getQuayById(quayRef).orElse(null);
   }
 }

--- a/src/main/java/no/entur/uttu/stopplace/NetexPublicationDeliveryFileStopPlaceRegistry.java
+++ b/src/main/java/no/entur/uttu/stopplace/NetexPublicationDeliveryFileStopPlaceRegistry.java
@@ -45,6 +45,8 @@ public class NetexPublicationDeliveryFileStopPlaceRegistry implements StopPlaceR
   private final Map<String, StopPlace> stopPlaceByQuayRefIndex =
     new ConcurrentHashMap<>();
 
+  private final Map<String, Quay> quayByQuayRefIndex = new ConcurrentHashMap<>();
+
   @Value("${uttu.stopplace.netex-file-uri}")
   String netexFileUri;
 
@@ -75,6 +77,7 @@ public class NetexPublicationDeliveryFileStopPlaceRegistry implements StopPlaceR
                     .forEach(quayRefOrQuay -> {
                       Quay quay = (Quay) quayRefOrQuay.getValue();
                       stopPlaceByQuayRefIndex.put(quay.getId(), stopPlace);
+                      quayByQuayRefIndex.put(quay.getId(), quay);
                     })
                 )
             );
@@ -107,6 +110,11 @@ public class NetexPublicationDeliveryFileStopPlaceRegistry implements StopPlaceR
       .stream()
       .filter(s -> isStopPlaceToBeIncluded(s, filters))
       .toList();
+  }
+
+  @Override
+  public Optional<Quay> getQuayById(String id) {
+    return Optional.ofNullable(quayByQuayRefIndex.get(id));
   }
 
   private boolean isStopPlaceToBeIncluded(

--- a/src/main/java/no/entur/uttu/stopplace/spi/StopPlaceRegistry.java
+++ b/src/main/java/no/entur/uttu/stopplace/spi/StopPlaceRegistry.java
@@ -37,4 +37,11 @@ public interface StopPlaceRegistry {
    * @return A list of all stop places satisfying the incoming filters
    */
   List<org.rutebanken.netex.model.StopPlace> getStopPlaces(List<StopPlaceFilter> filters);
+
+  /**
+   * Lookup a quay entity from its id
+   * @param id The id of the quay
+   * @return The quay entity
+   */
+  Optional<org.rutebanken.netex.model.Quay> getQuayById(String id);
 }

--- a/src/test/java/no/entur/uttu/export/netex/producer/common/ServiceLinkProducerTest.java
+++ b/src/test/java/no/entur/uttu/export/netex/producer/common/ServiceLinkProducerTest.java
@@ -1,0 +1,144 @@
+package no.entur.uttu.export.netex.producer.common;
+
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import no.entur.uttu.config.ExportTimeZone;
+import no.entur.uttu.export.model.ServiceLinkExportContext;
+import no.entur.uttu.export.netex.NetexExportContext;
+import no.entur.uttu.export.netex.producer.NetexObjectFactory;
+import no.entur.uttu.model.Codespace;
+import no.entur.uttu.model.Provider;
+import no.entur.uttu.model.Ref;
+import no.entur.uttu.model.VehicleModeEnumeration;
+import no.entur.uttu.model.job.Export;
+import no.entur.uttu.routing.RouteGeometry;
+import no.entur.uttu.routing.RoutingService;
+import no.entur.uttu.stopplace.spi.StopPlaceRegistry;
+import no.entur.uttu.util.DateUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.rutebanken.netex.model.LinkSequenceProjection;
+import org.rutebanken.netex.model.LocationStructure;
+import org.rutebanken.netex.model.Quay;
+import org.rutebanken.netex.model.ServiceLink;
+import org.rutebanken.netex.model.SimplePoint_VersionStructure;
+
+class ServiceLinkProducerTest {
+
+  ServiceLinkProducer serviceLinkProducer;
+  NetexObjectFactory objectFactory = new NetexObjectFactory(
+    new DateUtils(),
+    new ExportTimeZone()
+  );
+
+  StopPlaceRegistry mockStopPlaceRegistry = Mockito.mock(StopPlaceRegistry.class);
+  RoutingService mockRoutingService = Mockito.mock(RoutingService.class);
+
+  @BeforeEach
+  public void setUp() {
+    serviceLinkProducer =
+      new ServiceLinkProducer(objectFactory, mockStopPlaceRegistry, mockRoutingService);
+  }
+
+  @Test
+  void testServiceLinkProducerProducesCorrectLineString() {
+    Export export = new Export();
+    Provider provider = new Provider();
+    Codespace codespace = new Codespace();
+    codespace.setXmlns("TST");
+    provider.setCodespace(codespace);
+    export.setProvider(provider);
+    NetexExportContext context = new NetexExportContext(export);
+
+    context.serviceLinks =
+      Set.of(
+        new ServiceLinkExportContext(
+          "TST:Quay:1",
+          "TST:Quay:2",
+          VehicleModeEnumeration.BUS,
+          new Ref("TST:ServiceLink:1", "1")
+        )
+      );
+
+    Quay quayFrom = new Quay();
+    quayFrom.setId("TST:Quay:1");
+    quayFrom.setCentroid(
+      new SimplePoint_VersionStructure()
+        .withLocation(
+          new LocationStructure()
+            .withLongitude(BigDecimal.valueOf(10.1))
+            .withLatitude(BigDecimal.valueOf(60.2))
+        )
+    );
+
+    Quay quayTo = new Quay();
+    quayTo.setId("TST:Quay:2");
+    quayTo.setCentroid(
+      new SimplePoint_VersionStructure()
+        .withLocation(
+          new LocationStructure()
+            .withLongitude(BigDecimal.valueOf(10.5))
+            .withLatitude(BigDecimal.valueOf(60.6))
+        )
+    );
+
+    when(mockStopPlaceRegistry.getQuayById("TST:Quay:1"))
+      .thenReturn(Optional.of(quayFrom));
+    when(mockStopPlaceRegistry.getQuayById("TST:Quay:2")).thenReturn(Optional.of(quayTo));
+
+    // GeoJSON uses coordinate pairs in order longitude then latitude
+    when(
+      mockRoutingService.getRouteGeometry(
+        BigDecimal.valueOf(10.1),
+        BigDecimal.valueOf(60.2),
+        BigDecimal.valueOf(10.5),
+        BigDecimal.valueOf(60.6)
+      )
+    )
+      .thenReturn(
+        new RouteGeometry(
+          List.of(
+            List.of(BigDecimal.valueOf(10.1), BigDecimal.valueOf(60.2)),
+            List.of(BigDecimal.valueOf(10.2), BigDecimal.valueOf(60.3)),
+            List.of(BigDecimal.valueOf(10.3), BigDecimal.valueOf(60.4)),
+            List.of(BigDecimal.valueOf(10.4), BigDecimal.valueOf(60.5)),
+            List.of(BigDecimal.valueOf(10.5), BigDecimal.valueOf(60.6))
+          ),
+          BigDecimal.valueOf(100)
+        )
+      );
+
+    List<ServiceLink> serviceLinkList = serviceLinkProducer.produce(context);
+
+    LinkSequenceProjection linkSequenceProjection =
+      (LinkSequenceProjection) serviceLinkList
+        .getFirst()
+        .getProjections()
+        .getProjectionRefOrProjection()
+        .getFirst()
+        .getValue();
+
+    Assertions.assertEquals(
+      List.of(
+        // NeTEx expects coordinate pairs in order of latitude then longitude
+        60.2,
+        10.1,
+        60.3,
+        10.2,
+        60.4,
+        10.3,
+        60.5,
+        10.4,
+        60.6,
+        10.5
+      ),
+      linkSequenceProjection.getLineString().getPosList().getValue()
+    );
+  }
+}


### PR DESCRIPTION
The service links in exports had inverted coordinate pairs. NeTEx expects order to be latitude then longitude. This PR also has some refactoring / cleanup and adds a test for the service link producer.