### PR TITLE
Swith to correct enum in schema

### DIFF
--- a/src/main/java/no/entur/uttu/graphql/LinesGraphQLSchema.java
+++ b/src/main/java/no/entur/uttu/graphql/LinesGraphQLSchema.java
@@ -1191,8 +1191,8 @@ public class LinesGraphQLSchema {
             GraphQLArgument
               .newArgument()
               .name("mode")
-              .type(transportModeEnum)
-              .description("Transport mode")
+              .type(vehicleModeEnum)
+              .description("Vehicle mode")
               .build()
           )
           .description("Fetch service link containing route geometry")


### PR DESCRIPTION
Two different enums are used for transport modes, I chose the incorrect one here.