### PR TITLE
Make public code nullable on line input type

### DIFF
--- a/src/main/java/no/entur/uttu/graphql/LinesGraphQLSchema.java
+++ b/src/main/java/no/entur/uttu/graphql/LinesGraphQLSchema.java
@@ -1579,11 +1579,7 @@ public class LinesGraphQLSchema {
 
     GraphQLInputObjectType lineInputType = newInputObject(groupOfEntitiesInputType)
       .name("LineInput")
-      .field(
-        newInputObjectField()
-          .name(FIELD_PUBLIC_CODE)
-          .type(new GraphQLNonNull(GraphQLString))
-      )
+      .field(newInputObjectField().name(FIELD_PUBLIC_CODE).type(GraphQLString))
       .field(
         newInputObjectField()
           .name(FIELD_TRANSPORT_MODE)


### PR DESCRIPTION
Public code on line is optional in the nordic profile and in the database schema. We make it optional also in graphql to allow frontend to not set it. Use case is: When using branding, public code is not necessary.