### PR TITLE
Fix: not allowed to mutate orgs from registry

### DIFF
--- a/src/main/java/no/entur/uttu/export/netex/producer/common/OrganisationProducer.java
+++ b/src/main/java/no/entur/uttu/export/netex/producer/common/OrganisationProducer.java
@@ -110,7 +110,12 @@ public class OrganisationProducer {
       );
     }
 
-    return organisation.withId(getAuthorityNetexId(organisation));
+    return new Authority()
+      .withId(getAuthorityNetexId(organisation))
+      .withVersion(organisation.getVersion())
+      .withName(organisation.getName())
+      .withLegalName(organisation.getLegalName())
+      .withContactDetails(organisation.getContactDetails());
   }
 
   private boolean validateContactUrl(String url) {
@@ -131,8 +136,12 @@ public class OrganisationProducer {
 
     Operator organisation = orgRegOperator.get();
 
-    return organisation
+    return new Operator()
       .withId(getOperatorNetexId(organisation))
+      .withVersion(organisation.getVersion())
+      .withName(organisation.getName())
+      .withLegalName(organisation.getLegalName())
+      .withContactDetails(organisation.getContactDetails())
       .withCustomerServiceContactDetails(organisation.getContactDetails());
   }
 


### PR DESCRIPTION
If applied custom id to org during export, the original org object in the registry would be mutated, thus unable to look up in subsequent requests. The fix in this PR always makes a copy of orgs.