### PR TITLE
Remove PubSub emulator configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,6 @@
 
     <properties>
         <java.version>21</java.version>
-        <entur.google.pubsub.emulator.download.skip>true</entur.google.pubsub.emulator.download.skip>
 
         <entur.helpers.version>5.14</entur.helpers.version>
 


### PR DESCRIPTION
Remove the configuration for downloading the PubSub emulator in unit tests.
This configuration is not needed since the default value set in the superpom is "true".
Support for downloading the PubSub emulator is deprecated for removal and being replaced by testcontainer.