### PR TITLE
feat: add straight-line fallback routing when OSRM fails

### DIFF
--- a/src/main/java/no/entur/uttu/routing/osrm/OsrmService.java
+++ b/src/main/java/no/entur/uttu/routing/osrm/OsrmService.java
@@ -93,7 +93,6 @@ public class OsrmService implements no.entur.uttu.routing.RoutingService {
     RoutingServiceRequestParams requestParams,
     MutableRequest request
   ) {
-    List<List<BigDecimal>> routeCoordinates = new ArrayList<>();
     try {
       HttpResponse<String> response = httpClient.send(
         request,

--- a/src/main/java/no/entur/uttu/routing/osrm/OsrmService.java
+++ b/src/main/java/no/entur/uttu/routing/osrm/OsrmService.java
@@ -20,6 +20,8 @@ import java.util.Map;
 import no.entur.uttu.model.VehicleModeEnumeration;
 import no.entur.uttu.routing.RouteGeometry;
 import no.entur.uttu.routing.RoutingServiceRequestParams;
+import org.geotools.referencing.GeodeticCalculator;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -109,7 +111,7 @@ public class OsrmService implements no.entur.uttu.routing.RoutingService {
           requestParams.latitudeTo(),
           responseJsonNode.get("message").asText()
         );
-        return new RouteGeometry(routeCoordinates, BigDecimal.ZERO);
+        return createStraightLineRouteGeometry(requestParams);
       }
       JsonNode coordinates = responseJsonNode
         .get("routes")
@@ -143,6 +145,36 @@ public class OsrmService implements no.entur.uttu.routing.RoutingService {
       );
       Thread.currentThread().interrupt();
     }
-    return new RouteGeometry(routeCoordinates, BigDecimal.ZERO);
+    return createStraightLineRouteGeometry(requestParams);
+  }
+
+  private RouteGeometry createStraightLineRouteGeometry(
+    RoutingServiceRequestParams requestParams
+  ) {
+    List<List<BigDecimal>> coordinates = List.of(
+      List.of(requestParams.longitudeFrom(), requestParams.latitudeFrom()),
+      List.of(requestParams.longitudeTo(), requestParams.latitudeTo())
+    );
+
+    BigDecimal distance = calculateDistance(
+      requestParams.latitudeFrom(),
+      requestParams.longitudeFrom(),
+      requestParams.latitudeTo(),
+      requestParams.longitudeTo()
+    );
+
+    return new RouteGeometry(coordinates, distance);
+  }
+
+  private BigDecimal calculateDistance(
+    BigDecimal lat1,
+    BigDecimal lon1,
+    BigDecimal lat2,
+    BigDecimal lon2
+  ) {
+    GeodeticCalculator calculator = new GeodeticCalculator(DefaultGeographicCRS.WGS84);
+    calculator.setStartingGeographicPoint(lon1.doubleValue(), lat1.doubleValue());
+    calculator.setDestinationGeographicPoint(lon2.doubleValue(), lat2.doubleValue());
+    return BigDecimal.valueOf(calculator.getOrthodromicDistance());
   }
 }

--- a/src/test/java/no/entur/uttu/routing/osrm/OsrmServiceTest.java
+++ b/src/test/java/no/entur/uttu/routing/osrm/OsrmServiceTest.java
@@ -124,8 +124,8 @@ class OsrmServiceTest {
 
     // Then
     assertNotNull(geometry);
-    assertTrue(geometry.coordinates().isEmpty());
-    assertEquals(BigDecimal.ZERO, geometry.distance());
+    assertEquals(2, geometry.coordinates().size());
+    assertTrue(geometry.distance().compareTo(BigDecimal.ZERO) > 0);
     verify(httpClient).send(any(MutableRequest.class), eq(BodyHandlers.ofString()));
   }
 
@@ -149,8 +149,8 @@ class OsrmServiceTest {
 
     // Then
     assertNotNull(geometry);
-    assertTrue(geometry.coordinates().isEmpty());
-    assertEquals(BigDecimal.ZERO, geometry.distance());
+    assertEquals(2, geometry.coordinates().size());
+    assertTrue(geometry.distance().compareTo(BigDecimal.ZERO) > 0);
   }
 
   @Test
@@ -173,8 +173,8 @@ class OsrmServiceTest {
 
     // Then
     assertNotNull(geometry);
-    assertTrue(geometry.coordinates().isEmpty());
-    assertEquals(BigDecimal.ZERO, geometry.distance());
+    assertEquals(2, geometry.coordinates().size());
+    assertTrue(geometry.distance().compareTo(BigDecimal.ZERO) > 0);
     assertTrue(
       Thread.currentThread().isInterrupted(),
       "Thread should be marked as interrupted"


### PR DESCRIPTION
When OSRM routing engine cannot find a route between two stops, the service now falls back to creating a straight-line route with accurate distance calculation using GeoTools GeodeticCalculator.

- Added createStraightLineRouteGeometry() method
- Added calculateDistance() using GeoTools orthodromic distance
- Updated error handling to use fallback instead of empty geometry
- Updated tests to expect straight-line routes on OSRM failures

Closes #614 