### PR TITLE
Add validation for flexible area with nsr stops

### DIFF
--- a/src/main/java/no/entur/uttu/error/codederror/FlexibleAreaValidationCodedError.java
+++ b/src/main/java/no/entur/uttu/error/codederror/FlexibleAreaValidationCodedError.java
@@ -1,0 +1,23 @@
+package no.entur.uttu.error.codederror;
+
+import java.util.Map;
+import no.entur.uttu.error.codes.ErrorCodeEnumeration;
+
+public class FlexibleAreaValidationCodedError extends CodedError {
+
+  private static final String VALIDATION_MESSAGE_KEY = "validationMessage";
+
+  public static FlexibleAreaValidationCodedError fromValidationMessage(
+    String validationMessage
+  ) {
+    return new FlexibleAreaValidationCodedError(validationMessage);
+  }
+
+  private FlexibleAreaValidationCodedError(String validationMessage) {
+    super(
+      ErrorCodeEnumeration.FLEXIBLE_AREA_VALIDATION_FAILED,
+      null,
+      Map.of(VALIDATION_MESSAGE_KEY, validationMessage)
+    );
+  }
+}

--- a/src/main/java/no/entur/uttu/error/codes/ErrorCodeEnumeration.java
+++ b/src/main/java/no/entur/uttu/error/codes/ErrorCodeEnumeration.java
@@ -73,4 +73,9 @@ public enum ErrorCodeEnumeration implements ErrorCode {
    * If supplied stop place filter isn't something we support
    */
   INVALID_STOP_PLACE_FILTER,
+
+  /**
+   * Flexible area validation failed - area marked as UnrestrictedPublicTransportAreas must contain valid stop places
+   */
+  FLEXIBLE_AREA_VALIDATION_FAILED,
 }

--- a/src/main/java/no/entur/uttu/graphql/fetchers/FlexibleStopPlaceUpdater.java
+++ b/src/main/java/no/entur/uttu/graphql/fetchers/FlexibleStopPlaceUpdater.java
@@ -26,7 +26,6 @@ import no.entur.uttu.repository.StopPointInJourneyPatternRepository;
 import no.entur.uttu.repository.generic.ProviderEntityRepository;
 import no.entur.uttu.service.FlexibleAreaValidationService;
 import no.entur.uttu.util.Preconditions;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/no/entur/uttu/graphql/fetchers/FlexibleStopPlaceUpdater.java
+++ b/src/main/java/no/entur/uttu/graphql/fetchers/FlexibleStopPlaceUpdater.java
@@ -35,17 +35,18 @@ import org.springframework.transaction.annotation.Transactional;
 public class FlexibleStopPlaceUpdater
   extends AbstractProviderEntityUpdater<FlexibleStopPlace> {
 
-  @Autowired
-  private StopPointInJourneyPatternRepository stopPointInJourneyPatternRepository;
-
-  @Autowired
-  private FlexibleAreaValidationService flexibleAreaValidationService;
+  private final StopPointInJourneyPatternRepository stopPointInJourneyPatternRepository;
+  private final FlexibleAreaValidationService flexibleAreaValidationService;
 
   public FlexibleStopPlaceUpdater(
     AbstractProviderEntityMapper<FlexibleStopPlace> mapper,
-    ProviderEntityRepository<FlexibleStopPlace> repository
+    ProviderEntityRepository<FlexibleStopPlace> repository,
+    StopPointInJourneyPatternRepository stopPointInJourneyPatternRepository,
+    FlexibleAreaValidationService flexibleAreaValidationService
   ) {
     super(mapper, repository);
+    this.stopPointInJourneyPatternRepository = stopPointInJourneyPatternRepository;
+    this.flexibleAreaValidationService = flexibleAreaValidationService;
   }
 
   @Override

--- a/src/main/java/no/entur/uttu/graphql/mappers/FlexibleStopPlaceMapper.java
+++ b/src/main/java/no/entur/uttu/graphql/mappers/FlexibleStopPlaceMapper.java
@@ -121,7 +121,7 @@ public class FlexibleStopPlaceMapper
     return keyValues;
   }
 
-  protected String getVerifiedQuayRef(String quayRef) {
+  private String getVerifiedQuayRef(String quayRef) {
     return stopPlaceRegistry.getStopPlaceByQuayRef(quayRef).isPresent() ? quayRef : null;
   }
 }

--- a/src/main/java/no/entur/uttu/model/ValidationResult.java
+++ b/src/main/java/no/entur/uttu/model/ValidationResult.java
@@ -39,6 +39,10 @@ public class ValidationResult {
     return new ValidationResult(true, message, true);
   }
 
+  public static ValidationResult withInfo(String message) {
+    return new ValidationResult(true, message, false);
+  }
+
   public boolean isValid() {
     return valid;
   }

--- a/src/main/java/no/entur/uttu/model/ValidationResult.java
+++ b/src/main/java/no/entur/uttu/model/ValidationResult.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+
+package no.entur.uttu.model;
+
+public class ValidationResult {
+
+  private final boolean valid;
+  private final String message;
+  private final boolean hasWarnings;
+
+  private ValidationResult(boolean valid, String message, boolean hasWarnings) {
+    this.valid = valid;
+    this.message = message;
+    this.hasWarnings = hasWarnings;
+  }
+
+  public static ValidationResult valid() {
+    return new ValidationResult(true, null, false);
+  }
+
+  public static ValidationResult invalid(String message) {
+    return new ValidationResult(false, message, false);
+  }
+
+  public static ValidationResult withWarnings(String message) {
+    return new ValidationResult(true, message, true);
+  }
+
+  public boolean isValid() {
+    return valid;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public boolean hasWarnings() {
+    return hasWarnings;
+  }
+}

--- a/src/main/java/no/entur/uttu/service/FlexibleAreaValidationService.java
+++ b/src/main/java/no/entur/uttu/service/FlexibleAreaValidationService.java
@@ -40,12 +40,22 @@ public class FlexibleAreaValidationService {
   }
 
   public ValidationResult validateFlexibleStopPlace(FlexibleStopPlace flexibleStopPlace) {
-    if (!requiresValidation(flexibleStopPlace.getKeyValues())) {
-      return ValidationResult.valid();
-    }
+    boolean stopPlaceRequiresValidation = requiresValidation(
+      flexibleStopPlace.getKeyValues()
+    );
 
     for (FlexibleArea flexibleArea : flexibleStopPlace.getFlexibleAreas()) {
-      ValidationResult areaResult = validateFlexibleArea(flexibleArea);
+      ValidationResult areaResult;
+
+      // If stop place requires validation OR area requires validation, validate the area
+      if (
+        stopPlaceRequiresValidation || requiresValidation(flexibleArea.getKeyValues())
+      ) {
+        areaResult = validateFlexibleAreaContent(flexibleArea);
+      } else {
+        areaResult = ValidationResult.valid();
+      }
+
       if (!areaResult.isValid()) {
         return ValidationResult.invalid(
           "FlexibleStopPlace " +
@@ -66,6 +76,10 @@ public class FlexibleAreaValidationService {
       return ValidationResult.valid();
     }
 
+    return validateFlexibleAreaContent(flexibleArea);
+  }
+
+  private ValidationResult validateFlexibleAreaContent(FlexibleArea flexibleArea) {
     Polygon polygon = flexibleArea.getPolygon();
     if (polygon == null) {
       return ValidationResult.invalid(

--- a/src/main/java/no/entur/uttu/service/FlexibleAreaValidationService.java
+++ b/src/main/java/no/entur/uttu/service/FlexibleAreaValidationService.java
@@ -71,7 +71,7 @@ public class FlexibleAreaValidationService {
     return ValidationResult.valid();
   }
 
-  public ValidationResult validateFlexibleArea(FlexibleArea flexibleArea) {
+  protected ValidationResult validateFlexibleArea(FlexibleArea flexibleArea) {
     if (!requiresValidation(flexibleArea.getKeyValues())) {
       return ValidationResult.valid();
     }

--- a/src/main/java/no/entur/uttu/service/FlexibleAreaValidationService.java
+++ b/src/main/java/no/entur/uttu/service/FlexibleAreaValidationService.java
@@ -99,7 +99,7 @@ public class FlexibleAreaValidationService {
       );
     }
 
-    return ValidationResult.withWarnings(
+    return ValidationResult.withInfo(
       "FlexibleArea " +
       flexibleArea.getPk() +
       " contains " +

--- a/src/main/java/no/entur/uttu/service/FlexibleAreaValidationService.java
+++ b/src/main/java/no/entur/uttu/service/FlexibleAreaValidationService.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+
+package no.entur.uttu.service;
+
+import java.util.List;
+import java.util.Map;
+import no.entur.uttu.model.FlexibleArea;
+import no.entur.uttu.model.FlexibleStopPlace;
+import no.entur.uttu.model.ValidationResult;
+import no.entur.uttu.model.Value;
+import no.entur.uttu.stopplace.spi.StopPlaceRegistry;
+import org.locationtech.jts.geom.Polygon;
+import org.rutebanken.netex.model.StopPlace;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FlexibleAreaValidationService {
+
+  private static final String FLEXIBLE_STOP_AREA_TYPE_KEY = "FlexibleStopAreaType";
+  private static final String UNRESTRICTED_PUBLIC_TRANSPORT_AREAS_VALUE =
+    "UnrestrictedPublicTransportAreas";
+
+  private final StopPlaceRegistry stopPlaceRegistry;
+
+  public FlexibleAreaValidationService(StopPlaceRegistry stopPlaceRegistry) {
+    this.stopPlaceRegistry = stopPlaceRegistry;
+  }
+
+  public ValidationResult validateFlexibleStopPlace(FlexibleStopPlace flexibleStopPlace) {
+    if (!requiresValidation(flexibleStopPlace.getKeyValues())) {
+      return ValidationResult.valid();
+    }
+
+    for (FlexibleArea flexibleArea : flexibleStopPlace.getFlexibleAreas()) {
+      ValidationResult areaResult = validateFlexibleArea(flexibleArea);
+      if (!areaResult.isValid()) {
+        return ValidationResult.invalid(
+          "FlexibleStopPlace " +
+          flexibleStopPlace.getPk() +
+          " contains invalid FlexibleArea " +
+          flexibleArea.getPk() +
+          ": " +
+          areaResult.getMessage()
+        );
+      }
+    }
+
+    return ValidationResult.valid();
+  }
+
+  public ValidationResult validateFlexibleArea(FlexibleArea flexibleArea) {
+    if (!requiresValidation(flexibleArea.getKeyValues())) {
+      return ValidationResult.valid();
+    }
+
+    Polygon polygon = flexibleArea.getPolygon();
+    if (polygon == null) {
+      return ValidationResult.invalid(
+        "FlexibleArea " + flexibleArea.getPk() + " has no polygon defined"
+      );
+    }
+
+    List<StopPlace> stopPlacesInArea = stopPlaceRegistry.getStopPlacesWithinPolygon(
+      polygon
+    );
+
+    if (stopPlacesInArea.isEmpty()) {
+      return ValidationResult.invalid(
+        "FlexibleArea " +
+        flexibleArea.getPk() +
+        " with FlexibleStopAreaType=UnrestrictedPublicTransportAreas contains no valid stop places"
+      );
+    }
+
+    return ValidationResult.withWarnings(
+      "FlexibleArea " +
+      flexibleArea.getPk() +
+      " contains " +
+      stopPlacesInArea.size() +
+      " stop places"
+    );
+  }
+
+  private boolean requiresValidation(Map<String, Value> keyValues) {
+    if (keyValues == null || keyValues.isEmpty()) {
+      return false;
+    }
+
+    Value flexibleStopAreaType = keyValues.get(FLEXIBLE_STOP_AREA_TYPE_KEY);
+    if (flexibleStopAreaType == null || flexibleStopAreaType.getItems() == null) {
+      return false;
+    }
+
+    return flexibleStopAreaType
+      .getItems()
+      .contains(UNRESTRICTED_PUBLIC_TRANSPORT_AREAS_VALUE);
+  }
+}

--- a/src/main/java/no/entur/uttu/util/Preconditions.java
+++ b/src/main/java/no/entur/uttu/util/Preconditions.java
@@ -16,6 +16,7 @@
 package no.entur.uttu.util;
 
 import com.google.common.base.Strings;
+import java.util.function.Supplier;
 import no.entur.uttu.error.codederror.CodedError;
 import no.entur.uttu.error.codedexception.CodedIllegalArgumentException;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -32,6 +33,20 @@ public final class Preconditions {
       throw new CodedIllegalArgumentException(
         Strings.lenientFormat(errorMessageTemplate, errorMessageArgs),
         codedError
+      );
+    }
+  }
+
+  public static void checkArgument(
+    boolean expression,
+    Supplier<CodedError> codedErrorSupplier,
+    @Nullable String errorMessageTemplate,
+    @Nullable Object... errorMessageArgs
+  ) {
+    if (!expression) {
+      throw new CodedIllegalArgumentException(
+        Strings.lenientFormat(errorMessageTemplate, errorMessageArgs),
+        codedErrorSupplier.get()
       );
     }
   }

--- a/src/test/java/no/entur/uttu/graphql/fetchers/FlexibleStopPlaceUpdaterTest.java
+++ b/src/test/java/no/entur/uttu/graphql/fetchers/FlexibleStopPlaceUpdaterTest.java
@@ -30,6 +30,7 @@ import no.entur.uttu.model.FlexibleStopPlace;
 import no.entur.uttu.model.ValidationResult;
 import no.entur.uttu.model.VehicleModeEnumeration;
 import no.entur.uttu.repository.FlexibleStopPlaceRepository;
+import no.entur.uttu.repository.StopPointInJourneyPatternRepository;
 import no.entur.uttu.service.FlexibleAreaValidationService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,6 +51,9 @@ class FlexibleStopPlaceUpdaterTest {
   private FlexibleStopPlaceRepository repository;
 
   @Mock
+  private StopPointInJourneyPatternRepository stopPointInJourneyPatternRepository;
+
+  @Mock
   private FlexibleAreaValidationService flexibleAreaValidationService;
 
   @Mock
@@ -59,7 +63,13 @@ class FlexibleStopPlaceUpdaterTest {
 
   @BeforeEach
   void setUp() throws Exception {
-    updater = new FlexibleStopPlaceUpdater(mapper, repository);
+    updater =
+      new FlexibleStopPlaceUpdater(
+        mapper,
+        repository,
+        stopPointInJourneyPatternRepository,
+        flexibleAreaValidationService
+      );
 
     // Use reflection to set the private field
     Field field =

--- a/src/test/java/no/entur/uttu/graphql/fetchers/FlexibleStopPlaceUpdaterTest.java
+++ b/src/test/java/no/entur/uttu/graphql/fetchers/FlexibleStopPlaceUpdaterTest.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+
+package no.entur.uttu.graphql.fetchers;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import graphql.schema.DataFetchingEnvironment;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import no.entur.uttu.error.codedexception.CodedIllegalArgumentException;
+import no.entur.uttu.graphql.mappers.FlexibleStopPlaceMapper;
+import no.entur.uttu.model.FlexibleArea;
+import no.entur.uttu.model.FlexibleStopPlace;
+import no.entur.uttu.model.ValidationResult;
+import no.entur.uttu.model.VehicleModeEnumeration;
+import no.entur.uttu.repository.FlexibleStopPlaceRepository;
+import no.entur.uttu.service.FlexibleAreaValidationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Polygon;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FlexibleStopPlaceUpdaterTest {
+
+  @Mock
+  private FlexibleStopPlaceMapper mapper;
+
+  @Mock
+  private FlexibleStopPlaceRepository repository;
+
+  @Mock
+  private FlexibleAreaValidationService flexibleAreaValidationService;
+
+  @Mock
+  private DataFetchingEnvironment environment;
+
+  private FlexibleStopPlaceUpdater updater;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    updater = new FlexibleStopPlaceUpdater(mapper, repository);
+
+    // Use reflection to set the private field
+    Field field =
+      FlexibleStopPlaceUpdater.class.getDeclaredField("flexibleAreaValidationService");
+    field.setAccessible(true);
+    field.set(updater, flexibleAreaValidationService);
+  }
+
+  @Test
+  void shouldSaveValidFlexibleStopPlace() {
+    // Arrange
+    Map<String, Object> input = new HashMap<>();
+    FlexibleStopPlace flexibleStopPlace = createValidFlexibleStopPlace();
+
+    when(environment.getArgument("input")).thenReturn(input);
+    when(mapper.map(input)).thenReturn(flexibleStopPlace);
+    when(flexibleAreaValidationService.validateFlexibleStopPlace(flexibleStopPlace))
+      .thenReturn(ValidationResult.valid());
+    when(repository.save(flexibleStopPlace)).thenReturn(flexibleStopPlace);
+
+    // Act
+    FlexibleStopPlace result = updater.saveEntity(environment);
+
+    // Assert
+    assertNotNull(result);
+    verify(flexibleAreaValidationService).validateFlexibleStopPlace(flexibleStopPlace);
+    verify(repository).save(flexibleStopPlace);
+  }
+
+  @Test
+  void shouldThrowExceptionForInvalidFlexibleStopPlace() {
+    // Arrange
+    Map<String, Object> input = new HashMap<>();
+    FlexibleStopPlace flexibleStopPlace = createValidFlexibleStopPlace();
+
+    when(environment.getArgument("input")).thenReturn(input);
+    when(mapper.map(input)).thenReturn(flexibleStopPlace);
+    when(flexibleAreaValidationService.validateFlexibleStopPlace(flexibleStopPlace))
+      .thenReturn(ValidationResult.invalid("Test validation error"));
+
+    // Act & Assert
+    CodedIllegalArgumentException exception = assertThrows(
+      CodedIllegalArgumentException.class,
+      () -> updater.saveEntity(environment)
+    );
+
+    assertTrue(exception.getMessage().contains("Flexible stop place validation failed"));
+    assertTrue(exception.getMessage().contains("Test validation error"));
+    verify(flexibleAreaValidationService).validateFlexibleStopPlace(flexibleStopPlace);
+    verify(repository, never()).save(any());
+  }
+
+  @Test
+  void shouldSaveFlexibleStopPlaceWithWarnings() {
+    // Arrange
+    Map<String, Object> input = new HashMap<>();
+    FlexibleStopPlace flexibleStopPlace = createValidFlexibleStopPlace();
+
+    when(environment.getArgument("input")).thenReturn(input);
+    when(mapper.map(input)).thenReturn(flexibleStopPlace);
+    when(flexibleAreaValidationService.validateFlexibleStopPlace(flexibleStopPlace))
+      .thenReturn(ValidationResult.withWarnings("Test warning"));
+    when(repository.save(flexibleStopPlace)).thenReturn(flexibleStopPlace);
+
+    // Act
+    FlexibleStopPlace result = updater.saveEntity(environment);
+
+    // Assert
+    assertNotNull(result);
+    verify(flexibleAreaValidationService).validateFlexibleStopPlace(flexibleStopPlace);
+    verify(repository).save(flexibleStopPlace);
+  }
+
+  private FlexibleStopPlace createValidFlexibleStopPlace() {
+    FlexibleStopPlace flexibleStopPlace = new FlexibleStopPlace();
+    flexibleStopPlace.setTransportMode(VehicleModeEnumeration.BUS);
+
+    // Add a FlexibleArea to satisfy checkPersistable
+    FlexibleArea flexibleArea = new FlexibleArea();
+    GeometryFactory geometryFactory = new GeometryFactory();
+    Coordinate[] coordinates = {
+      new Coordinate(10.0, 60.0),
+      new Coordinate(11.0, 60.0),
+      new Coordinate(11.0, 61.0),
+      new Coordinate(10.0, 61.0),
+      new Coordinate(10.0, 60.0),
+    };
+    Polygon polygon = geometryFactory.createPolygon(coordinates);
+    flexibleArea.setPolygon(polygon);
+    flexibleArea.setFlexibleStopPlace(flexibleStopPlace);
+
+    flexibleStopPlace.setFlexibleAreas(List.of(flexibleArea));
+    return flexibleStopPlace;
+  }
+}

--- a/src/test/java/no/entur/uttu/service/FlexibleAreaValidationServiceTest.java
+++ b/src/test/java/no/entur/uttu/service/FlexibleAreaValidationServiceTest.java
@@ -1,0 +1,312 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+
+package no.entur.uttu.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import no.entur.uttu.model.FlexibleArea;
+import no.entur.uttu.model.FlexibleStopPlace;
+import no.entur.uttu.model.ValidationResult;
+import no.entur.uttu.model.Value;
+import no.entur.uttu.model.VehicleModeEnumeration;
+import no.entur.uttu.stopplace.spi.StopPlaceRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Polygon;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.rutebanken.netex.model.StopPlace;
+
+@ExtendWith(MockitoExtension.class)
+class FlexibleAreaValidationServiceTest {
+
+  @Mock
+  private StopPlaceRegistry stopPlaceRegistry;
+
+  private FlexibleAreaValidationService validationService;
+  private GeometryFactory geometryFactory;
+
+  @BeforeEach
+  void setUp() {
+    validationService = new FlexibleAreaValidationService(stopPlaceRegistry);
+    geometryFactory = new GeometryFactory();
+  }
+
+  @Test
+  void shouldValidateFlexibleStopPlaceWithoutFlexibleStopAreaType() {
+    FlexibleStopPlace flexibleStopPlace = createFlexibleStopPlace();
+    flexibleStopPlace.replaceKeyValues(new HashMap<>());
+
+    ValidationResult result = validationService.validateFlexibleStopPlace(
+      flexibleStopPlace
+    );
+
+    assertTrue(result.isValid());
+    assertNull(result.getMessage());
+    assertFalse(result.hasWarnings());
+  }
+
+  @Test
+  void shouldValidateFlexibleStopPlaceWithDifferentFlexibleStopAreaType() {
+    FlexibleStopPlace flexibleStopPlace = createFlexibleStopPlace();
+    Map<String, Value> keyValues = new HashMap<>();
+    keyValues.put("FlexibleStopAreaType", new Value("SomeOtherType"));
+    flexibleStopPlace.replaceKeyValues(keyValues);
+
+    ValidationResult result = validationService.validateFlexibleStopPlace(
+      flexibleStopPlace
+    );
+
+    assertTrue(result.isValid());
+    assertNull(result.getMessage());
+    assertFalse(result.hasWarnings());
+  }
+
+  @Test
+  void shouldValidateFlexibleStopPlaceWithUnrestrictedPublicTransportAreasAndValidAreas() {
+    FlexibleStopPlace flexibleStopPlace = createFlexibleStopPlace();
+    Map<String, Value> keyValues = new HashMap<>();
+    keyValues.put("FlexibleStopAreaType", new Value("UnrestrictedPublicTransportAreas"));
+    flexibleStopPlace.replaceKeyValues(keyValues);
+
+    FlexibleArea flexibleArea = createFlexibleArea();
+    flexibleStopPlace.setFlexibleAreas(List.of(flexibleArea));
+
+    ValidationResult result = validationService.validateFlexibleStopPlace(
+      flexibleStopPlace
+    );
+
+    assertTrue(result.isValid());
+    assertNull(result.getMessage());
+    assertFalse(result.hasWarnings());
+  }
+
+  @Test
+  void shouldInvalidateFlexibleStopPlaceWithUnrestrictedPublicTransportAreasAndInvalidAreas() {
+    FlexibleStopPlace flexibleStopPlace = createFlexibleStopPlace();
+    Map<String, Value> keyValues = new HashMap<>();
+    keyValues.put("FlexibleStopAreaType", new Value("UnrestrictedPublicTransportAreas"));
+    flexibleStopPlace.replaceKeyValues(keyValues);
+
+    FlexibleArea flexibleArea = createFlexibleArea();
+    Map<String, Value> areaKeyValues = new HashMap<>();
+    areaKeyValues.put(
+      "FlexibleStopAreaType",
+      new Value("UnrestrictedPublicTransportAreas")
+    );
+    flexibleArea.replaceKeyValues(areaKeyValues);
+    flexibleStopPlace.setFlexibleAreas(List.of(flexibleArea));
+
+    when(stopPlaceRegistry.getStopPlacesWithinPolygon(any(Polygon.class)))
+      .thenReturn(Collections.emptyList());
+
+    ValidationResult result = validationService.validateFlexibleStopPlace(
+      flexibleStopPlace
+    );
+
+    assertFalse(result.isValid());
+    assertTrue(result.getMessage().contains("contains invalid FlexibleArea"));
+    assertFalse(result.hasWarnings());
+  }
+
+  @Test
+  void shouldValidateFlexibleAreaWithoutFlexibleStopAreaType() {
+    FlexibleArea flexibleArea = createFlexibleArea();
+    flexibleArea.replaceKeyValues(new HashMap<>());
+
+    ValidationResult result = validationService.validateFlexibleArea(flexibleArea);
+
+    assertTrue(result.isValid());
+    assertNull(result.getMessage());
+    assertFalse(result.hasWarnings());
+  }
+
+  @Test
+  void shouldValidateFlexibleAreaWithDifferentFlexibleStopAreaType() {
+    FlexibleArea flexibleArea = createFlexibleArea();
+    Map<String, Value> keyValues = new HashMap<>();
+    keyValues.put("FlexibleStopAreaType", new Value("SomeOtherType"));
+    flexibleArea.replaceKeyValues(keyValues);
+
+    ValidationResult result = validationService.validateFlexibleArea(flexibleArea);
+
+    assertTrue(result.isValid());
+    assertNull(result.getMessage());
+    assertFalse(result.hasWarnings());
+  }
+
+  @Test
+  void shouldInvalidateFlexibleAreaWithoutPolygon() {
+    FlexibleArea flexibleArea = createFlexibleArea();
+    flexibleArea.setPolygon(null);
+    Map<String, Value> keyValues = new HashMap<>();
+    keyValues.put("FlexibleStopAreaType", new Value("UnrestrictedPublicTransportAreas"));
+    flexibleArea.replaceKeyValues(keyValues);
+
+    ValidationResult result = validationService.validateFlexibleArea(flexibleArea);
+
+    assertFalse(result.isValid());
+    assertTrue(result.getMessage().contains("has no polygon defined"));
+    assertFalse(result.hasWarnings());
+  }
+
+  @Test
+  void shouldInvalidateFlexibleAreaWithNoStopPlaces() {
+    FlexibleArea flexibleArea = createFlexibleArea();
+    Map<String, Value> keyValues = new HashMap<>();
+    keyValues.put("FlexibleStopAreaType", new Value("UnrestrictedPublicTransportAreas"));
+    flexibleArea.replaceKeyValues(keyValues);
+
+    when(stopPlaceRegistry.getStopPlacesWithinPolygon(any(Polygon.class)))
+      .thenReturn(Collections.emptyList());
+
+    ValidationResult result = validationService.validateFlexibleArea(flexibleArea);
+
+    assertFalse(result.isValid());
+    assertTrue(result.getMessage().contains("contains no valid stop places"));
+    assertFalse(result.hasWarnings());
+  }
+
+  @Test
+  void shouldValidateFlexibleAreaWithStopPlacesAndReturnWarnings() {
+    FlexibleArea flexibleArea = createFlexibleArea();
+    Map<String, Value> keyValues = new HashMap<>();
+    keyValues.put("FlexibleStopAreaType", new Value("UnrestrictedPublicTransportAreas"));
+    flexibleArea.replaceKeyValues(keyValues);
+
+    StopPlace stopPlace1 = new StopPlace();
+    StopPlace stopPlace2 = new StopPlace();
+    when(stopPlaceRegistry.getStopPlacesWithinPolygon(any(Polygon.class)))
+      .thenReturn(List.of(stopPlace1, stopPlace2));
+
+    ValidationResult result = validationService.validateFlexibleArea(flexibleArea);
+
+    assertTrue(result.isValid());
+    assertTrue(result.getMessage().contains("contains 2 stop places"));
+    assertTrue(result.hasWarnings());
+  }
+
+  @Test
+  void shouldHandleMultipleValuesInFlexibleStopAreaType() {
+    FlexibleArea flexibleArea = createFlexibleArea();
+    Map<String, Value> keyValues = new HashMap<>();
+    keyValues.put(
+      "FlexibleStopAreaType",
+      new Value("SomeOtherType", "UnrestrictedPublicTransportAreas")
+    );
+    flexibleArea.replaceKeyValues(keyValues);
+
+    StopPlace stopPlace = new StopPlace();
+    when(stopPlaceRegistry.getStopPlacesWithinPolygon(any(Polygon.class)))
+      .thenReturn(List.of(stopPlace));
+
+    ValidationResult result = validationService.validateFlexibleArea(flexibleArea);
+
+    assertTrue(result.isValid());
+    assertTrue(result.getMessage().contains("contains 1 stop places"));
+    assertTrue(result.hasWarnings());
+  }
+
+  @Test
+  void shouldHandleNullKeyValues() {
+    FlexibleArea flexibleArea = createFlexibleArea();
+    // Don't set keyValues to null since replaceKeyValues doesn't handle it
+    // Just use default empty map from createFlexibleArea()
+
+    ValidationResult result = validationService.validateFlexibleArea(flexibleArea);
+
+    assertTrue(result.isValid());
+    assertNull(result.getMessage());
+    assertFalse(result.hasWarnings());
+  }
+
+  @Test
+  void shouldHandleNullValueItems() {
+    FlexibleArea flexibleArea = createFlexibleArea();
+    Map<String, Value> keyValues = new HashMap<>();
+    Value value = new Value();
+    value.setItems(null);
+    keyValues.put("FlexibleStopAreaType", value);
+    flexibleArea.replaceKeyValues(keyValues);
+
+    ValidationResult result = validationService.validateFlexibleArea(flexibleArea);
+
+    assertTrue(result.isValid());
+    assertNull(result.getMessage());
+    assertFalse(result.hasWarnings());
+  }
+
+  @Test
+  void shouldHandleComplexFlexibleStopPlaceWithMixedAreas() {
+    FlexibleStopPlace flexibleStopPlace = createFlexibleStopPlace();
+    Map<String, Value> keyValues = new HashMap<>();
+    keyValues.put("FlexibleStopAreaType", new Value("UnrestrictedPublicTransportAreas"));
+    flexibleStopPlace.replaceKeyValues(keyValues);
+
+    FlexibleArea validArea = createFlexibleArea();
+    FlexibleArea invalidArea = createFlexibleArea();
+    Map<String, Value> invalidAreaKeyValues = new HashMap<>();
+    invalidAreaKeyValues.put(
+      "FlexibleStopAreaType",
+      new Value("UnrestrictedPublicTransportAreas")
+    );
+    invalidArea.replaceKeyValues(invalidAreaKeyValues);
+
+    flexibleStopPlace.setFlexibleAreas(List.of(validArea, invalidArea));
+
+    when(stopPlaceRegistry.getStopPlacesWithinPolygon(any(Polygon.class)))
+      .thenReturn(Collections.emptyList());
+
+    ValidationResult result = validationService.validateFlexibleStopPlace(
+      flexibleStopPlace
+    );
+
+    assertFalse(result.isValid());
+    assertTrue(result.getMessage().contains("contains invalid FlexibleArea"));
+    assertFalse(result.hasWarnings());
+  }
+
+  private FlexibleStopPlace createFlexibleStopPlace() {
+    FlexibleStopPlace flexibleStopPlace = new FlexibleStopPlace();
+    flexibleStopPlace.setTransportMode(VehicleModeEnumeration.BUS);
+    flexibleStopPlace.setFlexibleAreas(Collections.emptyList());
+    return flexibleStopPlace;
+  }
+
+  private FlexibleArea createFlexibleArea() {
+    FlexibleArea flexibleArea = new FlexibleArea();
+
+    Coordinate[] coordinates = {
+      new Coordinate(10.0, 60.0),
+      new Coordinate(11.0, 60.0),
+      new Coordinate(11.0, 61.0),
+      new Coordinate(10.0, 61.0),
+      new Coordinate(10.0, 60.0),
+    };
+    Polygon polygon = geometryFactory.createPolygon(coordinates);
+    flexibleArea.setPolygon(polygon);
+
+    return flexibleArea;
+  }
+}

--- a/src/test/java/no/entur/uttu/service/FlexibleAreaValidationServiceTest.java
+++ b/src/test/java/no/entur/uttu/service/FlexibleAreaValidationServiceTest.java
@@ -195,7 +195,7 @@ class FlexibleAreaValidationServiceTest {
   }
 
   @Test
-  void shouldValidateFlexibleAreaWithStopPlacesAndReturnWarnings() {
+  void shouldValidateFlexibleAreaWithStopPlacesAndReturnNoWarnings() {
     FlexibleArea flexibleArea = createFlexibleArea();
     Map<String, Value> keyValues = new HashMap<>();
     keyValues.put("FlexibleStopAreaType", new Value("UnrestrictedPublicTransportAreas"));
@@ -210,7 +210,7 @@ class FlexibleAreaValidationServiceTest {
 
     assertTrue(result.isValid());
     assertTrue(result.getMessage().contains("contains 2 stop places"));
-    assertTrue(result.hasWarnings());
+    assertFalse(result.hasWarnings());
   }
 
   @Test
@@ -231,7 +231,7 @@ class FlexibleAreaValidationServiceTest {
 
     assertTrue(result.isValid());
     assertTrue(result.getMessage().contains("contains 1 stop places"));
-    assertTrue(result.hasWarnings());
+    assertFalse(result.hasWarnings());
   }
 
   @Test


### PR DESCRIPTION
Validates that flexible area with type UNRESTRICTED_PUBLIC_TRANSPORT_AREA actually contain stops from stop place registry.

Validation is performed when saving the stop place itself, and when exporting lines that uses that stop place.

Closes #421 