### PR TITLE
fix(deps): update non-major dependencies (excl. netex-java-model)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       # Example: https://github.com/opentripplanner/OpenTripPlanner/actions/runs/4490450225/jobs/7897533439
       - uses: actions/setup-node@v6
         with:
-          node-version: 24.14.0
+          node-version: 24.16.0
 
       - name: Set up JDK 21
         uses: actions/setup-java@v5

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.entur.ror</groupId>
         <artifactId>superpom</artifactId>
-        <version>5.3.0</version>
+        <version>5.6.0</version>
     </parent>
 
     <groupId>no.rutebanken</groupId>
@@ -48,13 +48,13 @@
         <geotools.version>33.1</geotools.version>
         <wololo.version>0.18.1</wololo.version>
 
-        <commons-io.version>2.21.0</commons-io.version>
+        <commons-io.version>2.22.0</commons-io.version>
         <graphql.version>26.0</graphql.version>
         <graphql-extended-scalars.version>24.0</graphql-extended-scalars.version>
         <netex-java-model.version>2.0.15.2</netex-java-model.version>
 
         <jakarta-xml-bind.version>4.0.5</jakarta-xml-bind.version>
-        <glassfish-jaxb.version>4.0.7</glassfish-jaxb.version>
+        <glassfish-jaxb.version>4.0.9</glassfish-jaxb.version>
 
         <prettier-java.version>2.6.0</prettier-java.version>
         <prettier-maven-plugin.version>0.22</prettier-maven-plugin.version>
@@ -356,7 +356,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>2.0.3</version>
+            <version>2.0.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -495,7 +495,7 @@
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <phase>validate</phase>


### PR DESCRIPTION
## What

Consolidates the **safe** portion of the bundled Renovate PR #891, excluding bumps that need separate handling.

| Dependency | From | To |
|---|---|---|
| org.entur.ror:superpom | 5.3.0 | 5.6.0 |
| commons-io | 2.21.0 | 2.22.0 |
| glassfish-jaxb | 4.0.7 | 4.0.9 |
| org.testcontainers:testcontainers | 2.0.3 | 2.0.5 |
| spotless-maven-plugin | 3.3.0 | 3.6.0 |
| ci: node | 24.14.0 | 24.16.0 |

## Excluded from #891 (tracked separately)

- **netex-java-model 2.0.16** — breaking DatedServiceJourney change (caused the #888 revert) → #897
- **superpom major v6** — drops testcontainers BOM management; this PR takes only the safe 5.6.0 minor → #899
- **AWS deps** (awssdk bom, aws-secretsmanager-jdbc) — grouped with the AWS update work → #901

## Verification

`./mvnw clean install` green locally — **489 tests, 0 failures/errors** (rebased on master incl. graphql-java v26).

Closes #891
Refs #897, #899, #901
