### PR TITLE
Fix dev crashloop after Boot 4.0: remove unused @EnableCaching

### DIFF
--- a/src/main/java/no/entur/uttu/App.java
+++ b/src/main/java/no/entur/uttu/App.java
@@ -21,7 +21,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.boot.security.autoconfigure.UserDetailsServiceAutoConfiguration;
-import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.jpa.convert.threeten.Jsr310JpaConverters;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
@@ -32,7 +31,6 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
   repositoryBaseClass = ProviderEntityRepositoryImpl.class
 )
 @EntityScan(basePackageClasses = { Provider.class, Jsr310JpaConverters.class })
-@EnableCaching
 @ComponentScan(
   basePackages = { "no.entur.uttu", "org.rutebanken.helper.stopplace.changelog" }
 )


### PR DESCRIPTION
## Problem

After #902 (Spring Boot 4.0) was merged to dev, the pod went into **CrashLoopBackOff**. The startup probe failed because the app never started — from the pod's Cloud Logging:

```
APPLICATION FAILED TO START
A component required a bean of type 'org.springframework.cache.CacheManager' that could not be found.
NoSuchBeanDefinitionException: ... no CacheResolver specified - register a CacheManager
bean or remove the @EnableCaching annotation
```

## Cause

`App` is annotated `@EnableCaching`. In Boot 3.x that fell back to a default `ConcurrentMapCacheManager`; **Boot 4.0 extracted cache auto-configuration into the `spring-boot-cache` module**, which isn't on the classpath, so no `CacheManager` is created and context initialization fails.

uttu doesn't use Spring's caching abstraction anywhere:
- no `@Cacheable` / `@CacheEvict` / `@CachePut` / `CacheManager` in the codebase
- the `@Cache` annotations on `Value`/`FlexibleArea`/`FlexibleStopPlace` are **Hibernate** second-level cache (separate subsystem, no L2 provider configured anyway)
- `FintrafficUserContextService` uses **Guava** `LoadingCache`

So `@EnableCaching` is dead config. Removing it is the fix the error message itself suggests.

## Why CI / the 489 tests didn't catch it

The integration tests boot **`UttuTestApp`**, which does not carry `@EnableCaching`. Only the production `App` class does, and no test boots `App`. The failure is therefore only reachable at real startup.

## Verification

Booted `App` locally with the Boot 4.0 build (local profiles): it now initialises **past** the cache stage — the `CacheManager` error is gone. (Local run then hit an unrelated DB-role artifact from force-enabling Flyway against a fresh container; not applicable in dev, where the schema/roles already exist.)

## Follow-up

Worth adding a smoke test that boots the real `App` context (not just `UttuTestApp`) so production-only wiring is covered by CI.
