### PR TITLE
Update AWS dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <prettier-maven-plugin.version>0.22</prettier-maven-plugin.version>
         <plugin.prettier.goal>write</plugin.prettier.goal>
 
-        <awssdk.version>2.42.13</awssdk.version>
+        <awssdk.version>2.46.10</awssdk.version>
     </properties>
 
     <distributionManagement>
@@ -309,13 +309,13 @@
         <dependency>
             <groupId>io.awspring.cloud</groupId>
             <artifactId>spring-cloud-aws-starter-secrets-manager</artifactId>
-            <version>3.4.2</version>
+            <version>4.0.2</version>
         </dependency>
         <!-- AWS: acquire and refresh jdbc credentials from Secrets Manager in cloud environments -->
         <dependency>
             <groupId>com.amazonaws.secretsmanager</groupId>
             <artifactId>aws-secretsmanager-jdbc</artifactId>
-            <version>2.0.4</version>
+            <version>2.1.2</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### Summary
Update aws dependencies after Spring boot 4 update.  Resolves issue: #901.

| Dependency | From | To |
|---|---|---|
| software.amazon.awssdk | 2.42.13 | 2.46.10 |
| spring-cloud-aws-starter-secrets-manager | 3.4.2 | 4.0.2 |
| aws-secretsmanager-jdbc | 2.0.4 | 2.1.2 |


- [x] Bump the three AWS deps above
- [x] ./mvnw clean install green