### PR TITLE
fix(deps): ungroup netex-java-model and add dedicated AWS group in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,15 @@
     {
       "matchPackageNames": ["com.github.mizosoft.methanol:methanol"],
       "groupName": null
+    },
+    {
+      "matchPackageNames": ["org.entur:netex-java-model"],
+      "groupName": null
+    },
+    {
+      "groupName": "aws",
+      "matchDatasources": ["maven"],
+      "matchPackageNames": ["software.amazon.awssdk:**", "com.amazonaws:**", "com.amazonaws.secretsmanager:**", "io.awspring.cloud:**"]
     }
   ]
 }


### PR DESCRIPTION
## Why

Renovate's `allNonMajor` group currently bundles `org.entur:netex-java-model` together with routine minor/patch bumps (see #904). That dependency's bumps can carry **breaking changes** — e.g. v2.0.16 realigns `DatedServiceJourney` on CEN NeTEx — so it shouldn't ride along silently in a grouped update.

Separately, AWS dependencies were scattered across the catch-all group.

## Changes

- **Ungroup `netex-java-model`** — set `groupName: null` so it gets its own isolated PR (same pattern already used for `methanol`).
- **Dedicated `aws` group** — collects all AWS-touching deps into one PR:
  - `software.amazon.awssdk:**`
  - `com.amazonaws:**` / `com.amazonaws.secretsmanager:**`
  - `io.awspring.cloud:**`
