### PR TITLE
fix(deps): Renovate grouping + geotools registry lookup

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,11 +13,13 @@
     },
     {
       "matchPackageNames": ["com.github.mizosoft.methanol:methanol"],
-      "groupName": null
+      "groupName": "methanol",
+      "groupSlug": "methanol"
     },
     {
       "matchPackageNames": ["org.entur:netex-java-model"],
-      "groupName": null
+      "groupName": "netex-java-model",
+      "groupSlug": "netex-java-model"
     },
     {
       "groupName": "aws",


### PR DESCRIPTION
Two Renovate config fixes (`renovate.json`).

## 1. Give netex-java-model its own PR (fix `groupName: null`)

After #907, AWS deps split out correctly but `netex-java-model` stayed grouped in #904.

**Root cause:** `group:allNonMajor` sets both `groupName: "all non-major dependencies"` and `groupSlug: "all-minor-patch"`. The rule overrode only `groupName` → `null`, leaving the inherited `groupSlug` in place, so Renovate kept bucketing the package into the `all-minor-patch` branch. The `aws` rule avoided this because a string `groupName` makes Renovate recompute the slug.

**Fix:** give `netex-java-model` (and `methanol`, same latent bug) an explicit `groupName` + `groupSlug`.

## 2. Fix `org.geotools` lookup via OSGeo registry

Renovate warns: *Failed to look up maven package org.geotools:gt-geojson: no-result*. GeoTools is published to the OSGeo repository, not Maven Central. Add a `registryUrls` packageRule pointing at `repo.osgeo.org` (Maven Central as fallback).