### PR TITLE
Add VehicleTypeRef as a non-validated property to ServiceJourney

### DIFF
--- a/src/main/java/no/entur/uttu/export/netex/producer/line/ServiceJourneyProducer.java
+++ b/src/main/java/no/entur/uttu/export/netex/producer/line/ServiceJourneyProducer.java
@@ -74,8 +74,11 @@ public class ServiceJourneyProducer {
   ) {
     OperatorRefStructure operatorRefStructure = null;
     if (local.getOperatorRef() != null) {
-      operatorRefStructure =
-        organisationProducer.produceOperatorRef(local.getOperatorRef(), false, context);
+      operatorRefStructure = organisationProducer.produceOperatorRef(
+        local.getOperatorRef(),
+        false,
+        context
+      );
       context.operatorRefs.add(local.getOperatorRef());
     }
 
@@ -91,13 +94,14 @@ public class ServiceJourneyProducer {
       .map(ttpt -> mapTimetabledPassingTime(ttpt, noticeAssignments, context))
       .collect(toList());
 
-    JAXBElement<JourneyPatternRefStructure> journeyPatternRef = objectFactory.wrapAsJAXBElement(
-      objectFactory.populateRefStructure(
-        new JourneyPatternRefStructure(),
-        local.getJourneyPattern().getRef(),
-        true
-      )
-    );
+    JAXBElement<JourneyPatternRefStructure> journeyPatternRef =
+      objectFactory.wrapAsJAXBElement(
+        objectFactory.populateRefStructure(
+          new JourneyPatternRefStructure(),
+          local.getJourneyPattern().getRef(),
+          true
+        )
+      );
 
     noticeAssignments.addAll(
       objectFactory.createNoticeAssignments(local, local.getNotices(), context)
@@ -120,9 +124,10 @@ public class ServiceJourneyProducer {
       .withDayTypes(dayTypeRefs);
 
     if (local.getVehicleTypeRef() != null) {
-      JAXBElement<VehicleTypeRefStructure> vehicleTypeRef = objectFactory.wrapAsJAXBElement(
-        new VehicleTypeRefStructure().withRef(local.getVehicleTypeRef())
-      );
+      JAXBElement<VehicleTypeRefStructure> vehicleTypeRef =
+        objectFactory.wrapAsJAXBElement(
+          new VehicleTypeRefStructure().withRef(local.getVehicleTypeRef())
+        );
       serviceJourney.withVehicleTypeRef(vehicleTypeRef);
     }
     return serviceJourney;
@@ -137,11 +142,12 @@ public class ServiceJourneyProducer {
       .getDayTypes()
       .stream()
       .filter(context::isValid)
-      .filter(dayType ->
-        dayType
-          .getDayTypeAssignments()
-          .stream()
-          .anyMatch(dta -> (!dta.getOperatingPeriod().getToDate().isBefore(cutoff)))
+      .filter(
+        dayType ->
+          dayType
+            .getDayTypeAssignments()
+            .stream()
+            .anyMatch(dta -> (!dta.getOperatingPeriod().getToDate().isBefore(cutoff)))
       )
       .toList();
   }
@@ -158,8 +164,13 @@ public class ServiceJourneyProducer {
       .withDayTypeRef(
         validDayTypes
           .stream()
-          .map(dt ->
-            objectFactory.wrapRefStructure(new DayTypeRefStructure(), dt.getRef(), false)
+          .map(
+            dt ->
+              objectFactory.wrapRefStructure(
+                new DayTypeRefStructure(),
+                dt.getRef(),
+                false
+              )
           )
           .collect(toList())
       );
@@ -182,14 +193,13 @@ public class ServiceJourneyProducer {
       .filter(sp -> sp.getOrder() == local.getOrder())
       .findFirst();
     if (stopPointInJourneyPattern.isPresent()) {
-      pointInJourneyPatternRef =
-        objectFactory.wrapAsJAXBElement(
-          objectFactory.populateRefStructure(
-            new StopPointInJourneyPatternRefStructure(),
-            stopPointInJourneyPattern.get().getRef(),
-            true
-          )
-        );
+      pointInJourneyPatternRef = objectFactory.wrapAsJAXBElement(
+        objectFactory.populateRefStructure(
+          new StopPointInJourneyPatternRefStructure(),
+          stopPointInJourneyPattern.get().getRef(),
+          true
+        )
+      );
     } else {
       context.addExportMessage(
         SeverityEnumeration.ERROR,

--- a/src/main/java/no/entur/uttu/export/netex/producer/line/ServiceJourneyProducer.java
+++ b/src/main/java/no/entur/uttu/export/netex/producer/line/ServiceJourneyProducer.java
@@ -74,11 +74,8 @@ public class ServiceJourneyProducer {
   ) {
     OperatorRefStructure operatorRefStructure = null;
     if (local.getOperatorRef() != null) {
-      operatorRefStructure = organisationProducer.produceOperatorRef(
-        local.getOperatorRef(),
-        false,
-        context
-      );
+      operatorRefStructure =
+        organisationProducer.produceOperatorRef(local.getOperatorRef(), false, context);
       context.operatorRefs.add(local.getOperatorRef());
     }
 
@@ -94,14 +91,13 @@ public class ServiceJourneyProducer {
       .map(ttpt -> mapTimetabledPassingTime(ttpt, noticeAssignments, context))
       .collect(toList());
 
-    JAXBElement<JourneyPatternRefStructure> journeyPatternRef =
-      objectFactory.wrapAsJAXBElement(
-        objectFactory.populateRefStructure(
-          new JourneyPatternRefStructure(),
-          local.getJourneyPattern().getRef(),
-          true
-        )
-      );
+    JAXBElement<JourneyPatternRefStructure> journeyPatternRef = objectFactory.wrapAsJAXBElement(
+      objectFactory.populateRefStructure(
+        new JourneyPatternRefStructure(),
+        local.getJourneyPattern().getRef(),
+        true
+      )
+    );
 
     noticeAssignments.addAll(
       objectFactory.createNoticeAssignments(local, local.getNotices(), context)
@@ -123,11 +119,10 @@ public class ServiceJourneyProducer {
       )
       .withDayTypes(dayTypeRefs);
 
-    if(local.getVehicleTypeRef() != null) {
-      JAXBElement<VehicleTypeRefStructure> vehicleTypeRef =
-        objectFactory.wrapAsJAXBElement(
-          new VehicleTypeRefStructure().withRef(local.getVehicleTypeRef())
-        );
+    if (local.getVehicleTypeRef() != null) {
+      JAXBElement<VehicleTypeRefStructure> vehicleTypeRef = objectFactory.wrapAsJAXBElement(
+        new VehicleTypeRefStructure().withRef(local.getVehicleTypeRef())
+      );
       serviceJourney.withVehicleTypeRef(vehicleTypeRef);
     }
     return serviceJourney;
@@ -142,12 +137,11 @@ public class ServiceJourneyProducer {
       .getDayTypes()
       .stream()
       .filter(context::isValid)
-      .filter(
-        dayType ->
-          dayType
-            .getDayTypeAssignments()
-            .stream()
-            .anyMatch(dta -> (!dta.getOperatingPeriod().getToDate().isBefore(cutoff)))
+      .filter(dayType ->
+        dayType
+          .getDayTypeAssignments()
+          .stream()
+          .anyMatch(dta -> (!dta.getOperatingPeriod().getToDate().isBefore(cutoff)))
       )
       .toList();
   }
@@ -164,13 +158,8 @@ public class ServiceJourneyProducer {
       .withDayTypeRef(
         validDayTypes
           .stream()
-          .map(
-            dt ->
-              objectFactory.wrapRefStructure(
-                new DayTypeRefStructure(),
-                dt.getRef(),
-                false
-              )
+          .map(dt ->
+            objectFactory.wrapRefStructure(new DayTypeRefStructure(), dt.getRef(), false)
           )
           .collect(toList())
       );
@@ -193,13 +182,14 @@ public class ServiceJourneyProducer {
       .filter(sp -> sp.getOrder() == local.getOrder())
       .findFirst();
     if (stopPointInJourneyPattern.isPresent()) {
-      pointInJourneyPatternRef = objectFactory.wrapAsJAXBElement(
-        objectFactory.populateRefStructure(
-          new StopPointInJourneyPatternRefStructure(),
-          stopPointInJourneyPattern.get().getRef(),
-          true
-        )
-      );
+      pointInJourneyPatternRef =
+        objectFactory.wrapAsJAXBElement(
+          objectFactory.populateRefStructure(
+            new StopPointInJourneyPatternRefStructure(),
+            stopPointInJourneyPattern.get().getRef(),
+            true
+          )
+        );
     } else {
       context.addExportMessage(
         SeverityEnumeration.ERROR,

--- a/src/main/java/no/entur/uttu/export/netex/producer/line/ServiceJourneyProducer.java
+++ b/src/main/java/no/entur/uttu/export/netex/producer/line/ServiceJourneyProducer.java
@@ -108,7 +108,7 @@ public class ServiceJourneyProducer {
     );
     context.notices.addAll(local.getNotices());
 
-    return objectFactory
+    org.rutebanken.netex.model.ServiceJourney serviceJourney = objectFactory
       .populate(new org.rutebanken.netex.model.ServiceJourney(), local)
       .withJourneyPatternRef(journeyPatternRef)
       .withName(objectFactory.createMultilingualString(local.getName()))
@@ -122,6 +122,15 @@ public class ServiceJourneyProducer {
           .withTimetabledPassingTime(timetabledPassingTimes)
       )
       .withDayTypes(dayTypeRefs);
+
+    if(local.getVehicleTypeRef() != null) {
+      JAXBElement<VehicleTypeRefStructure> vehicleTypeRef =
+        objectFactory.wrapAsJAXBElement(
+          new VehicleTypeRefStructure().withRef(local.getVehicleTypeRef())
+        );
+      serviceJourney.withVehicleTypeRef(vehicleTypeRef);
+    }
+    return serviceJourney;
   }
 
   private @NotNull List<DayType> listValidDayTypes(

--- a/src/main/java/no/entur/uttu/graphql/GraphQLNames.java
+++ b/src/main/java/no/entur/uttu/graphql/GraphQLNames.java
@@ -32,6 +32,7 @@ public class GraphQLNames {
   public static final String FIELD_TRANSPORT_MODE = "transportMode";
   public static final String FIELD_TRANSPORT_SUBMODE = "transportSubmode";
   public static final String FIELD_OPERATOR_REF = "operatorRef";
+  public static final String FIELD_VEHICLE_TYPE_REF = "vehicleTypeRef";
   public static final String FIELD_POINTS_IN_SEQUENCE = "pointsInSequence";
   public static final String FIELD_BOOKING_ARRANGEMENT = "bookingArrangement";
   public static final String FIELD_NOTICES = "notices";

--- a/src/main/java/no/entur/uttu/graphql/LinesGraphQLSchema.java
+++ b/src/main/java/no/entur/uttu/graphql/LinesGraphQLSchema.java
@@ -586,6 +586,7 @@ public class LinesGraphQLSchema {
       .name("ServiceJourney")
       .field(newFieldDefinition().name(FIELD_PUBLIC_CODE).type(GraphQLString))
       .field(newFieldDefinition().name(FIELD_OPERATOR_REF).type(GraphQLString))
+      .field(newFieldDefinition().name(FIELD_VEHICLE_TYPE_REF).type(GraphQLString))
       .field(
         newFieldDefinition()
           .name(FIELD_BOOKING_ARRANGEMENT)
@@ -1352,6 +1353,7 @@ public class LinesGraphQLSchema {
       .name("ServiceJourneyInput")
       .field(newInputObjectField().name(FIELD_PUBLIC_CODE).type(GraphQLString))
       .field(newInputObjectField().name(FIELD_OPERATOR_REF).type(GraphQLString))
+      .field(newInputObjectField().name(FIELD_VEHICLE_TYPE_REF).type(GraphQLString))
       .field(
         newInputObjectField()
           .name(FIELD_BOOKING_ARRANGEMENT)

--- a/src/main/java/no/entur/uttu/graphql/mappers/ServiceJourneyMapper.java
+++ b/src/main/java/no/entur/uttu/graphql/mappers/ServiceJourneyMapper.java
@@ -71,10 +71,7 @@ public class ServiceJourneyMapper extends AbstractGroupOfEntitiesMapper<ServiceJ
       },
       entity::setOperatorRef
     );
-    input.apply(
-      FIELD_VEHICLE_TYPE_REF,
-      entity::setVehicleTypeRef
-    );
+    input.apply(FIELD_VEHICLE_TYPE_REF, entity::setVehicleTypeRef);
     input.apply(
       FIELD_BOOKING_ARRANGEMENT,
       bookingArrangementMapper::map,

--- a/src/main/java/no/entur/uttu/graphql/mappers/ServiceJourneyMapper.java
+++ b/src/main/java/no/entur/uttu/graphql/mappers/ServiceJourneyMapper.java
@@ -72,6 +72,10 @@ public class ServiceJourneyMapper extends AbstractGroupOfEntitiesMapper<ServiceJ
       entity::setOperatorRef
     );
     input.apply(
+      FIELD_VEHICLE_TYPE_REF,
+      entity::setVehicleTypeRef
+    );
+    input.apply(
       FIELD_BOOKING_ARRANGEMENT,
       bookingArrangementMapper::map,
       entity::setBookingArrangement

--- a/src/main/java/no/entur/uttu/model/ServiceJourney.java
+++ b/src/main/java/no/entur/uttu/model/ServiceJourney.java
@@ -45,7 +45,7 @@ import org.hibernate.annotations.FetchMode;
     @UniqueConstraint(
       name = SERVICE_JOURNEY_UNIQUE_NAME,
       columnNames = { "provider_pk", "name" }
-    ),
+    )
   }
 )
 @BatchSize(size = 100)
@@ -111,6 +111,7 @@ public class ServiceJourney extends GroupOfEntities_VersionStructure {
   public String getVehicleTypeRef() {
     return vehicleTypeRef;
   }
+
   public void setVehicleTypeRef(String vehicleTypeRef) {
     this.vehicleTypeRef = vehicleTypeRef;
   }

--- a/src/main/java/no/entur/uttu/model/ServiceJourney.java
+++ b/src/main/java/no/entur/uttu/model/ServiceJourney.java
@@ -45,7 +45,7 @@ import org.hibernate.annotations.FetchMode;
     @UniqueConstraint(
       name = SERVICE_JOURNEY_UNIQUE_NAME,
       columnNames = { "provider_pk", "name" }
-    )
+    ),
   }
 )
 @BatchSize(size = 100)

--- a/src/main/java/no/entur/uttu/model/ServiceJourney.java
+++ b/src/main/java/no/entur/uttu/model/ServiceJourney.java
@@ -55,6 +55,8 @@ public class ServiceJourney extends GroupOfEntities_VersionStructure {
 
   private String operatorRef;
 
+  private String vehicleTypeRef;
+
   @OneToOne(cascade = CascadeType.ALL)
   @Fetch(FetchMode.JOIN)
   private BookingArrangement bookingArrangement;
@@ -104,6 +106,13 @@ public class ServiceJourney extends GroupOfEntities_VersionStructure {
       }
       this.passingTimes.addAll(passingTimes);
     }
+  }
+
+  public String getVehicleTypeRef() {
+    return vehicleTypeRef;
+  }
+  public void setVehicleTypeRef(String vehicleTypeRef) {
+    this.vehicleTypeRef = vehicleTypeRef;
   }
 
   public String getPublicCode() {

--- a/src/main/resources/db/migration/V23__Add_VehicleTypeRef.sql
+++ b/src/main/resources/db/migration/V23__Add_VehicleTypeRef.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ONLY SERVICE_JOURNEY
+    ADD COLUMN vehicle_type_ref character varying(255);

--- a/src/test/java/no/entur/uttu/export/netex/producer/line/ServiceJourneyProducerTest.java
+++ b/src/test/java/no/entur/uttu/export/netex/producer/line/ServiceJourneyProducerTest.java
@@ -1,8 +1,7 @@
 package no.entur.uttu.export.netex.producer.line;
 
 import static no.entur.uttu.model.DayTypeTest.period;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.time.Clock;
@@ -110,10 +109,7 @@ class ServiceJourneyProducerTest {
     );
     assertNotNull(sj, "ServiceJourney should be produced when day types are valid");
     assertNotNull(sj.getVehicleTypeRef(), "VehicleTypeRef should be set");
-    org.junit.jupiter.api.Assertions.assertEquals(
-      "NMR:VehicleType:123",
-      sj.getVehicleTypeRef().getValue().getRef()
-    );
+    assertEquals("NMR:VehicleType:123", sj.getVehicleTypeRef().getValue().getRef());
   }
 
   @Test

--- a/src/test/java/no/entur/uttu/export/netex/producer/line/ServiceJourneyProducerTest.java
+++ b/src/test/java/no/entur/uttu/export/netex/producer/line/ServiceJourneyProducerTest.java
@@ -39,22 +39,20 @@ class ServiceJourneyProducerTest {
 
   @BeforeEach
   void setUp() {
-    objectFactory =
-      new NetexObjectFactory(
-        new DateUtils(),
-        new ExportTimeZone(),
-        new AdditionalCodespacesConfig()
-      );
+    objectFactory = new NetexObjectFactory(
+      new DateUtils(),
+      new ExportTimeZone(),
+      new AdditionalCodespacesConfig()
+    );
     contactStructureProducer = new ContactStructureProducer(objectFactory);
     organisationProducer = mock(OrganisationProducer.class);
     Clock clock = Clock.systemDefaultZone();
-    producer =
-      new ServiceJourneyProducer(
-        objectFactory,
-        contactStructureProducer,
-        organisationProducer,
-        clock
-      );
+    producer = new ServiceJourneyProducer(
+      objectFactory,
+      contactStructureProducer,
+      organisationProducer,
+      clock
+    );
     local = mock(ServiceJourney.class, RETURNS_DEEP_STUBS);
     journeyPattern = mock(JourneyPattern.class);
     no.entur.uttu.model.Ref jpRef = new no.entur.uttu.model.Ref("JP:1", "1");

--- a/src/test/java/no/entur/uttu/export/netex/producer/line/ServiceJourneyProducerTest.java
+++ b/src/test/java/no/entur/uttu/export/netex/producer/line/ServiceJourneyProducerTest.java
@@ -64,6 +64,7 @@ class ServiceJourneyProducerTest {
     when(local.getBookingArrangement()).thenReturn(null);
     when(local.getPublicCode()).thenReturn("PCODE");
     when(local.getRef()).thenReturn(new no.entur.uttu.model.Ref("SJ:1", "1"));
+    when(local.getVehicleTypeRef()).thenReturn("NMR:VehicleType:123");
     noticeAssignments = new ArrayList<>();
   }
 
@@ -89,6 +90,23 @@ class ServiceJourneyProducerTest {
     assertNull(
       sj.getDayTypes(),
       "DayTypes should not be set when includeDatedServiceJourneys is true"
+    );
+  }
+
+  @Test
+  void produce_shouldReturnVehicleTypeRef() {
+    export = new Export();
+    export.setIncludeDatedServiceJourneys(true);
+    context = new NetexExportContext(export);
+
+    org.rutebanken.netex.model.ServiceJourney sj = producer.produce(
+      local,
+      noticeAssignments,
+      context
+    );
+    assertNotNull(
+      sj.getVehicleTypeRef(),
+      "VehicleTypeRef should be set"
     );
   }
 

--- a/src/test/java/no/entur/uttu/export/netex/producer/line/ServiceJourneyProducerTest.java
+++ b/src/test/java/no/entur/uttu/export/netex/producer/line/ServiceJourneyProducerTest.java
@@ -99,12 +99,21 @@ class ServiceJourneyProducerTest {
     export.setIncludeDatedServiceJourneys(true);
     context = new NetexExportContext(export);
 
+    DayType dayType = new DayType();
+    dayType.getDayTypeAssignments().add(period(LocalDate.MIN, LocalDate.MAX));
+    setDayTypes(Set.of(dayType));
+
     org.rutebanken.netex.model.ServiceJourney sj = producer.produce(
       local,
       noticeAssignments,
       context
     );
+    assertNotNull(sj, "ServiceJourney should be produced when day types are valid");
     assertNotNull(sj.getVehicleTypeRef(), "VehicleTypeRef should be set");
+    org.junit.jupiter.api.Assertions.assertEquals(
+      "NMR:VehicleType:123",
+      sj.getVehicleTypeRef().getValue().getRef()
+    );
   }
 
   @Test

--- a/src/test/java/no/entur/uttu/export/netex/producer/line/ServiceJourneyProducerTest.java
+++ b/src/test/java/no/entur/uttu/export/netex/producer/line/ServiceJourneyProducerTest.java
@@ -39,20 +39,22 @@ class ServiceJourneyProducerTest {
 
   @BeforeEach
   void setUp() {
-    objectFactory = new NetexObjectFactory(
-      new DateUtils(),
-      new ExportTimeZone(),
-      new AdditionalCodespacesConfig()
-    );
+    objectFactory =
+      new NetexObjectFactory(
+        new DateUtils(),
+        new ExportTimeZone(),
+        new AdditionalCodespacesConfig()
+      );
     contactStructureProducer = new ContactStructureProducer(objectFactory);
     organisationProducer = mock(OrganisationProducer.class);
     Clock clock = Clock.systemDefaultZone();
-    producer = new ServiceJourneyProducer(
-      objectFactory,
-      contactStructureProducer,
-      organisationProducer,
-      clock
-    );
+    producer =
+      new ServiceJourneyProducer(
+        objectFactory,
+        contactStructureProducer,
+        organisationProducer,
+        clock
+      );
     local = mock(ServiceJourney.class, RETURNS_DEEP_STUBS);
     journeyPattern = mock(JourneyPattern.class);
     no.entur.uttu.model.Ref jpRef = new no.entur.uttu.model.Ref("JP:1", "1");
@@ -104,10 +106,7 @@ class ServiceJourneyProducerTest {
       noticeAssignments,
       context
     );
-    assertNotNull(
-      sj.getVehicleTypeRef(),
-      "VehicleTypeRef should be set"
-    );
+    assertNotNull(sj.getVehicleTypeRef(), "VehicleTypeRef should be set");
   }
 
   @Test


### PR DESCRIPTION
### Summary

This adds support for serviceJourney.vehicleTypeRef into the model, allowing to register plan data connected to vehicle types in the vehicle registry