### PR TITLE
Fix problem with max 256KB size of response

### DIFF
--- a/src/ext/java/no/entur/uttu/ext/entur/organisation/client/NetexOrganisationRegistryClient.java
+++ b/src/ext/java/no/entur/uttu/ext/entur/organisation/client/NetexOrganisationRegistryClient.java
@@ -1,10 +1,10 @@
 package no.entur.uttu.ext.entur.organisation.client;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.util.unit.DataSize;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -12,31 +12,21 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Profile("entur-netex-organisation-registry-client")
 public class NetexOrganisationRegistryClient {
 
-  @Value("${netex.organisations.max-in-memory-size-kb:500}")
-  String maxInMemorySizeKB;
+  @Value("${netex.organisations.max-in-memory-size:500KB}")
+  DataSize maxInMemorySize;
 
   @Bean("orgRegisterClient")
   WebClient webClient(WebClient.Builder webClientBuilder) {
     return webClientBuilder
       .defaultHeader("Et-Client-Name", "entur-nplan")
       .exchangeStrategies(
-        ExchangeStrategies
-          .builder()
-          .codecs(codecs ->
-            codecs.defaultCodecs().maxInMemorySize(resolveMaxInMemorySizeBytes())
+        ExchangeStrategies.builder()
+          .codecs(
+            codecs ->
+              codecs.defaultCodecs().maxInMemorySize((int) maxInMemorySize.toBytes())
           )
           .build()
       )
       .build();
-  }
-
-  private int resolveMaxInMemorySizeBytes() {
-    long maxInMemorySizeKb;
-    try {
-      maxInMemorySizeKb = Long.parseLong(maxInMemorySizeKB);
-    } catch (NumberFormatException e) {
-      maxInMemorySizeKb = 500L;
-    }
-    return (int) (maxInMemorySizeKb * 1024);
   }
 }

--- a/src/ext/java/no/entur/uttu/ext/entur/organisation/client/NetexOrganisationRegistryClient.java
+++ b/src/ext/java/no/entur/uttu/ext/entur/organisation/client/NetexOrganisationRegistryClient.java
@@ -16,15 +16,14 @@ public class NetexOrganisationRegistryClient {
   String maxInMemorySizeKB;
 
   @Bean("orgRegisterClient")
-  @ConditionalOnMissingBean(name = "orgRegisterClient")
   WebClient webClient(WebClient.Builder webClientBuilder) {
     return webClientBuilder
       .defaultHeader("Et-Client-Name", "entur-nplan")
       .exchangeStrategies(
-        ExchangeStrategies.builder()
-          .codecs(
-            codecs ->
-              codecs.defaultCodecs().maxInMemorySize(resolveMaxInMemorySizeBytes())
+        ExchangeStrategies
+          .builder()
+          .codecs(codecs ->
+            codecs.defaultCodecs().maxInMemorySize(resolveMaxInMemorySizeBytes())
           )
           .build()
       )

--- a/src/ext/java/no/entur/uttu/ext/entur/organisation/client/NetexOrganisationRegistryClient.java
+++ b/src/ext/java/no/entur/uttu/ext/entur/organisation/client/NetexOrganisationRegistryClient.java
@@ -1,16 +1,43 @@
 package no.entur.uttu.ext.entur.organisation.client;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 @Profile("entur-netex-organisation-registry-client")
 public class NetexOrganisationRegistryClient {
 
+  @Value("${netex.organisations.max-in-memory-size-kb:500}")
+  String maxInMemorySizeKB;
+
   @Bean("orgRegisterClient")
+  @ConditionalOnMissingBean(name = "orgRegisterClient")
   WebClient webClient(WebClient.Builder webClientBuilder) {
-    return webClientBuilder.defaultHeader("Et-Client-Name", "entur-nplan").build();
+    return webClientBuilder
+      .defaultHeader("Et-Client-Name", "entur-nplan")
+      .exchangeStrategies(
+        ExchangeStrategies
+          .builder()
+          .codecs(codecs ->
+            codecs.defaultCodecs().maxInMemorySize(resolveMaxInMemorySizeBytes())
+          )
+          .build()
+      )
+      .build();
+  }
+
+  private int resolveMaxInMemorySizeBytes() {
+    long maxInMemorySizeKb;
+    try {
+      maxInMemorySizeKb = Long.parseLong(maxInMemorySizeKB);
+    } catch (NumberFormatException e) {
+      maxInMemorySizeKb = 500L;
+    }
+    return (int) (maxInMemorySizeKb * 1024);
   }
 }

--- a/src/ext/java/no/entur/uttu/ext/entur/organisation/client/NetexOrganisationRegistryClient.java
+++ b/src/ext/java/no/entur/uttu/ext/entur/organisation/client/NetexOrganisationRegistryClient.java
@@ -21,10 +21,10 @@ public class NetexOrganisationRegistryClient {
     return webClientBuilder
       .defaultHeader("Et-Client-Name", "entur-nplan")
       .exchangeStrategies(
-        ExchangeStrategies
-          .builder()
-          .codecs(codecs ->
-            codecs.defaultCodecs().maxInMemorySize(resolveMaxInMemorySizeBytes())
+        ExchangeStrategies.builder()
+          .codecs(
+            codecs ->
+              codecs.defaultCodecs().maxInMemorySize(resolveMaxInMemorySizeBytes())
           )
           .build()
       )


### PR DESCRIPTION
### Summary

Fixes the following error:

If the response from https://api.entur.io/agreements/v1/adapter/transmodel/export was more than 256KB, the call would fail with the error message:
```
Caused by: [org.springframework.core.io](http://org.springframework.core.io/).buffer.DataBufferLimitException: Exceeded limit on max bytes to buffer : 262144
	at [org.springframework.core.io](http://org.springframework.core.io/).buffer.LimitedDataBufferList.raiseLimitException(LimitedDataBufferList.java:99)
	Suppressed: The stacktrace has been enhanced by Reactor, refer to additional information below: 
Error has been observed at the following site(s):
	*__checkpoint ⇢ Body from GET https://api.entur.io/agreements/v1/adapter/transmodel/export [DefaultClientResponse]
```